### PR TITLE
[MPC] support I control term for quadrotor with attitude/bodyrate control mode

### DIFF
--- a/aerial_robot_control/include/aerial_robot_control/nmpc/under_act_body_rate/nmpc_controller.h
+++ b/aerial_robot_control/include/aerial_robot_control/nmpc/under_act_body_rate/nmpc_controller.h
@@ -11,6 +11,7 @@
 #pragma once
 
 #include "aerial_robot_control/control/base/base.h"
+#include <aerial_robot_control/control/base/pose_linear_controller.h>
 #include "aerial_robot_control/nmpc/under_act_body_rate/mpc_solver.h"
 // #include <aerial_robot_control/control/utils/pid.h>
 // #include <aerial_robot_control/PIDConfig.h>
@@ -42,7 +43,7 @@ namespace aerial_robot_control
 namespace nmpc_under_act_body_rate
 {
 
-class NMPCController : public ControlBase
+class NMPCController : public PoseLinearController
 {
 public:
   NMPCController();  // note that constructor should not have arguments as the rule of rospluginlib

--- a/aerial_robot_control/src/nmpc/under_act_body_rate/nmpc_controller.cpp
+++ b/aerial_robot_control/src/nmpc/under_act_body_rate/nmpc_controller.cpp
@@ -226,23 +226,6 @@ void nmpc_under_act_body_rate::NMPCController::controlCore()
   // constraint the change of thrust, preventing sudden thrust increasing during taking off
   for (int i = 0; i < motor_num_; i++)
   {
-    if (navigator_->getNaviState() == aerial_robot_navigation::TAKEOFF_STATE)
-    {
-      float max_thrust_change = 10.0 / 40.0;
-
-      if (target_thrusts(i) > flight_cmd_.base_thrust[i] + max_thrust_change)
-      {
-        flight_cmd_.base_thrust[i] = flight_cmd_.base_thrust[i] + max_thrust_change;
-        continue;
-      }
-
-      if (target_thrusts(i) < flight_cmd_.base_thrust[i] - max_thrust_change)
-      {
-        flight_cmd_.base_thrust[i] = flight_cmd_.base_thrust[i] - max_thrust_change;
-        continue;
-      }
-    }
-
     flight_cmd_.base_thrust[i] = static_cast<float>(target_thrusts(i));
   }
 

--- a/aerial_robot_control/src/nmpc/under_act_body_rate/nmpc_controller.cpp
+++ b/aerial_robot_control/src/nmpc/under_act_body_rate/nmpc_controller.cpp
@@ -7,7 +7,11 @@
 
 using namespace aerial_robot_control;
 
-nmpc_under_act_body_rate::NMPCController::NMPCController() : target_roll_(0), target_pitch_(0), candidate_yaw_term_(0)
+nmpc_under_act_body_rate::NMPCController::NMPCController() :
+  PoseLinearController(),
+  target_roll_(0),
+  target_pitch_(0),
+  candidate_yaw_term_(0)
 {
 }
 
@@ -16,7 +20,7 @@ void nmpc_under_act_body_rate::NMPCController::initialize(
     boost::shared_ptr<aerial_robot_estimation::StateEstimator> estimator,
     boost::shared_ptr<aerial_robot_navigation::BaseNavigator> navigator, double ctrl_loop_du)
 {
-  ControlBase::initialize(nh, nhp, robot_model, estimator, navigator, ctrl_loop_du);
+  PoseLinearController::initialize(nh, nhp, robot_model, estimator, navigator, ctrl_loop_du);
 
   ros::NodeHandle control_nh(nh_, "controller");
 
@@ -88,7 +92,7 @@ bool nmpc_under_act_body_rate::NMPCController::update()
 
 void nmpc_under_act_body_rate::NMPCController::reset()
 {
-  ControlBase::reset();
+  PoseLinearController::reset();
 
   sendRPYGain();                // tmp for angular gains  TODO: change to angular gains only
   sendRotationalInertiaComp();  // tmp for inertia
@@ -145,6 +149,8 @@ nav_msgs::Odometry nmpc_under_act_body_rate::NMPCController::getOdom()
 
 void nmpc_under_act_body_rate::NMPCController::controlCore()
 {
+  PoseLinearController::controlCore();
+
   /* get odom information */
   nav_msgs::Odometry odom_now = getOdom();
 
@@ -233,11 +239,43 @@ void nmpc_under_act_body_rate::NMPCController::controlCore()
 
     flight_cmd_.base_thrust[i] = static_cast<float>(target_thrusts(i));
   }
+
+  /* I term to compensate the model error */
+  tf::Vector3 target_acc_w(pid_controllers_.at(X).getITerm(),
+                           pid_controllers_.at(Y).getITerm(),
+                           pid_controllers_.at(Z).getITerm());
+
+  double yaw = rpy_.z();
+  tf::Vector3 target_acc_dash = (tf::Matrix3x3(tf::createQuaternionFromYaw(yaw))).inverse() * target_acc_w;
+
+  Eigen::VectorXd target_thrust_z_term;
+  // hovering approximation
+  // x & y
+  double i_term_pitch = target_acc_dash.x() / aerial_robot_estimation::G;
+  double i_term_roll = -target_acc_dash.y() / aerial_robot_estimation::G;
+  flight_cmd_.angles[0] += static_cast<float>(i_term_pitch);
+  flight_cmd_.angles[1] += static_cast<float>(i_term_roll);
+
+  // z
+  Eigen::VectorXd f = robot_model_->getStaticThrust();
+  Eigen::VectorXd allocate_scales = f / g.norm();
+  Eigen::VectorXd i_term_thrust = allocate_scales * target_acc_w.length();
+  for (int i = 0; i < motor_num_; i++)
+  {
+    flight_cmd_.base_thrust.at(i) += static_cast<float>(i_term_thrust(i));
+  }
+
+  // yaw
+  Eigen::Matrix3d inertia = robot_model_->getInertia<Eigen::Matrix3d>();
+  double i_term_yaw = inertia(2,2) * pid_controllers_.at(YAW).getITerm();
+  flight_cmd_.angles[2] += static_cast<float>(i_term_yaw);
 }
 
 void nmpc_under_act_body_rate::NMPCController::sendCmd()
 {
   pub_flight_cmd_.publish(flight_cmd_);
+
+  PoseLinearController::sendCmd();
 }
 
 /**

--- a/aerial_robot_control/src/nmpc/under_act_body_rate/nmpc_controller.cpp
+++ b/aerial_robot_control/src/nmpc/under_act_body_rate/nmpc_controller.cpp
@@ -62,10 +62,16 @@ void nmpc_under_act_body_rate::NMPCController::initialize(
 
   /* services */
   srv_set_control_mode_ = nh_.serviceClient<spinal::SetControlMode>("set_control_mode");
+  bool res = ros::service::waitForService("set_control_mode", ros::Duration(5));
 
   reset();
 
   // set control mode
+  if (!res)
+    {
+      ROS_ERROR("cannot find service named set_control_mode");
+    }
+  ros::Duration(2.0).sleep();
   spinal::SetControlMode set_control_mode_srv;
   set_control_mode_srv.request.is_attitude = is_attitude_ctrl_;
   set_control_mode_srv.request.is_body_rate = is_body_rate_ctrl_;

--- a/aerial_robot_control/src/nmpc/under_act_full/nmpc_controller.cpp
+++ b/aerial_robot_control/src/nmpc/under_act_full/nmpc_controller.cpp
@@ -54,10 +54,16 @@ void nmpc_under_act_full::NMPCController::initialize(
 
   /* services */
   srv_set_control_mode_ = nh_.serviceClient<spinal::SetControlMode>("set_control_mode");
+  bool res = ros::service::waitForService("set_control_mode", ros::Duration(5));
 
   reset();
 
   // set control mode
+  if (!res)
+    {
+      ROS_ERROR("cannot find service named set_control_mode");
+    }
+  ros::Duration(2.0).sleep();
   spinal::SetControlMode set_control_mode_srv;
   set_control_mode_srv.request.is_attitude = is_attitude_ctrl_;
   set_control_mode_srv.request.is_body_rate = is_body_rate_ctrl_;

--- a/aerial_robot_control/src/nmpc/under_act_full/nmpc_controller.cpp
+++ b/aerial_robot_control/src/nmpc/under_act_full/nmpc_controller.cpp
@@ -224,23 +224,6 @@ void nmpc_under_act_full::NMPCController::controlCore()
   // constraint the change of thrust, preventing sudden thrust increasing during taking off
   for (int i = 0; i < motor_num_; i++)
   {
-    if (navigator_->getNaviState() == aerial_robot_navigation::TAKEOFF_STATE)
-    {
-      float max_thrust_change = 10.0 / 40.0;
-
-      if (target_thrusts(i) > flight_cmd_.base_thrust[i] + max_thrust_change)
-      {
-        flight_cmd_.base_thrust[i] = flight_cmd_.base_thrust[i] + max_thrust_change;
-        continue;
-      }
-
-      if (target_thrusts(i) < flight_cmd_.base_thrust[i] - max_thrust_change)
-      {
-        flight_cmd_.base_thrust[i] = flight_cmd_.base_thrust[i] - max_thrust_change;
-        continue;
-      }
-    }
-
     flight_cmd_.base_thrust[i] = static_cast<float>(target_thrusts(i));
   }
 }

--- a/robots/mini_quadrotor/config/FlightControlNMPCBodyRate.yaml
+++ b/robots/mini_quadrotor/config/FlightControlNMPCBodyRate.yaml
@@ -37,7 +37,7 @@ controller:
     limit_i: 1.5
 
   z:
-    i_gain: 1.0
+    i_gain: 2.0
     limit_i: 5 # m / s^2
 
   yaw:

--- a/robots/mini_quadrotor/config/FlightControlNMPCBodyRate.yaml
+++ b/robots/mini_quadrotor/config/FlightControlNMPCBodyRate.yaml
@@ -31,3 +31,15 @@ controller:
 
     is_attitude_ctrl: true
     is_body_rate_ctrl: true
+
+  xy:
+    i_gain: 0.5
+    limit_i: 1.5
+
+  z:
+    i_gain: 1.0
+    limit_i: 5 # m / s^2
+
+  yaw:
+    i_gain: 0.1
+    limit_i: 4.0


### PR DESCRIPTION
### What is this

Add I control term to compensate the steady-state error of X/Y/Z/Yaw. 
Evaluated in the real quadrotor platform.

### Details

- X and Y is compensated by adding the additional roll/pitch angle calcuated from the I term of acceleration of X and Y
- Z is compesnated by adding the additional acceleration of Z
- Yaw is compensated by adding the torque directly.

### Video 

- [x] add video 


https://github.com/Li-Jinjie/jsk_aerial_robot_dev/assets/45286479/de39c343-9506-4944-b679-3c731c6cbf0d




https://github.com/Li-Jinjie/jsk_aerial_robot_dev/assets/45286479/1b8402f7-bdd2-484c-b676-436b9727aa25

