### PR TITLE
[Motor Test] add new plot PWM_ratio_% vs fz and python2 compatibility

### DIFF
--- a/aerial_robot_nerve/motor_test/scripts/analyze_data.py
+++ b/aerial_robot_nerve/motor_test/scripts/analyze_data.py
@@ -4,7 +4,7 @@ import pandas as pd
 import matplotlib.pyplot as plt
 
 
-def analyze_data(folder_path, file_name, has_telemetry, set_voltage):
+def analyze_data(folder_path, file_name, has_telemetry, set_voltage, order):
     file_path = folder_path + file_name
     column_names = []
     if not has_telemetry:
@@ -85,14 +85,13 @@ def analyze_data(folder_path, file_name, has_telemetry, set_voltage):
     fit_eq_currency_fz = f"currency = {coeffs_currency_fz[0]:.4e} * fz^2 + {coeffs_currency_fz[1]:.4e} * fz + {coeffs_currency_fz[2]:.4f}"
     print(f"Fitting Equation (x:fz y:currency): {fit_eq_currency_fz}")
 
-    # 2nd-order polynomial fit for x:PWM_ratio y:fz
-    coeffs_PWM_ratio_fz = np.polyfit(PWM_ratio, fz, 2)
+    # polynomial fit for x:PWM_ratio y:fz
+    coeffs_PWM_ratio_fz = np.polyfit(PWM_ratio, fz, order)
     fit_eq_PWM_ratio_fz = f"fz = {coeffs_PWM_ratio_fz[0]:.4e} * PWM_Ratio_%^2 + {coeffs_PWM_ratio_fz[1]:.4e} * PWM_Ratio_% + {coeffs_PWM_ratio_fz[2]:.4f}"
     print(f"Fitting Equation (x:PWM_Ratio_% y:fz): {fit_eq_PWM_ratio_fz}")
     print(f"max fz: {np.max(fz):.4f} N")
-    print(f"polynominal2(10x): {10 * coeffs_PWM_ratio_fz[0]:.5f}")
-    print(f"polynominal1(10x): {10 * coeffs_PWM_ratio_fz[1]:.5f}")
-    print(f"polynominal0: {coeffs_PWM_ratio_fz[2]:.5f}")
+    for i in range(order + 1):
+        print("polynomial{}: {}".format(order - i, pow(10, order - i) * coeffs_PWM_ratio_fz[i]))
 
     # Create 3x2 subplots
     fig, axs = plt.subplots(3, 2, figsize=(12, 18))
@@ -173,7 +172,8 @@ if __name__ == '__main__':
     parser.add_argument('file_name', help='file name')
     parser.add_argument('has_telemetry', help='has telemetry, 0 or 1')
     parser.add_argument("--set_voltage", help="the voltage set in the test, float", default=0.0)
+    parser.add_argument("--order", help="fitting order of fz vs PWM_ratio", default=2)
     parser.add_argument('--folder_path', help='path to folder', default='~/.ros/')
     args = parser.parse_args()
 
-    analyze_data(args.folder_path, args.file_name, int(args.has_telemetry), float(args.set_voltage))
+    analyze_data(args.folder_path, args.file_name, int(args.has_telemetry), float(args.set_voltage), int(args.order))

--- a/aerial_robot_nerve/motor_test/scripts/analyze_data.py
+++ b/aerial_robot_nerve/motor_test/scripts/analyze_data.py
@@ -101,7 +101,7 @@ def analyze_data(folder_path, file_name, has_telemetry, set_voltage, order):
     fit_eq_fz_PWM_ratio = "PWM_ratio_% = "
     for i in range(order + 1):
         fit_eq_fz_PWM_ratio += "\n{:.4e} * fz^{} + ".format(coeffs_fz_PWM_ratio[i], order - i)
-    print("Fitting Equation (x:fz y:PWM_Ratio_%): {fit_eq_fz_PWM_ratio}")
+    print("Fitting Equation (x:fz y:PWM_Ratio_%): {}".format(fit_eq_fz_PWM_ratio))
     print("voltage: {}".format(set_voltage))
     print("max_thrust: {:.4f} # N".format(np.max(fz)))
     for i in range(order + 1):

--- a/aerial_robot_nerve/motor_test/scripts/analyze_data.py
+++ b/aerial_robot_nerve/motor_test/scripts/analyze_data.py
@@ -37,7 +37,7 @@ def analyze_data(folder_path, file_name, has_telemetry, set_voltage, order):
     # Add a column for power
     if has_telemetry:
         average_values['Power'] = average_values['voltage'] * average_values['currency']
-        print(f"Average voltage: {average_values['voltage'].mean()}")
+        print("Average voltage: {}".format(average_values['voltage'].mean()))
     else:
         average_values['Power'] = set_voltage * average_values['currency']
 
@@ -67,45 +67,45 @@ def analyze_data(folder_path, file_name, has_telemetry, set_voltage, order):
     if has_telemetry:
         # Linear fit for x:kRPM^2 y:fz
         slope_kRPM2, intercept_kRPM2 = np.polyfit(kRPM2, fz, 1)
-        fit_eq_kRPM2 = f"fz = {slope_kRPM2:.4f} * kRPM^2 + {intercept_kRPM2:.4f}"
-        print(f"Fitting Equation (x:kRPM^2 y:fz): {fit_eq_kRPM2}")
+        fit_eq_kRPM2 = "fz = {:.4f} * kRPM^2 + {:.4f}".format(slope_kRPM2, intercept_kRPM2)
+        print("Fitting Equation (x:kRPM^2 y:fz): {}".format(fit_eq_kRPM2))
 
         # Linear fit for x: pwm_ratio y: kRPM
         slope_kRPM_PWM_ratio, intercept_kRPM_PWM_ratio = np.polyfit(PWM_ratio, kRPM, 1)
-        fit_eq_kRPM_PWM_ratio = f"kRPM = {slope_kRPM_PWM_ratio:.4f} * PWM_Ratio_% + {intercept_kRPM_PWM_ratio:.4f}"
-        print(f"Fitting Equation (x:PWM_Ratio_% y:kRPM): {fit_eq_kRPM_PWM_ratio}")
+        fit_eq_kRPM_PWM_ratio = "kRPM = {:.4f} * PWM_Ratio_% + {:.4f}".format(slope_kRPM_PWM_ratio, intercept_kRPM_PWM_ratio)
+        print("Fitting Equation (x:PWM_Ratio_% y:kRPM): {}".format(fit_eq_kRPM_PWM_ratio))
 
     # Linear fit for x:fz y:mz, note that the intercept must be 0. Only y=kx form.
     slope_mz_fz, intercept_mz_fz = np.polyfit(fz, mz, 1)
-    fit_eq_mz_fz = f"mz = {slope_mz_fz:.4f} * fz"
-    print(f"Fitting Equation (x:fz y:mz): {fit_eq_mz_fz}")
+    fit_eq_mz_fz = "mz = {:.4f} * fz".format(slope_mz_fz)
+    print("Fitting Equation (x:fz y:mz): {}".format(fit_eq_mz_fz))
 
     # 2nd-order polynomial fit for x:fz y:currency
     coeffs_currency_fz = np.polyfit(fz, currency, 2)
-    fit_eq_currency_fz = f"currency = {coeffs_currency_fz[0]:.4e} * fz^2 + {coeffs_currency_fz[1]:.4e} * fz + {coeffs_currency_fz[2]:.4f}"
-    print(f"Fitting Equation (x:fz y:currency): {fit_eq_currency_fz}")
+    fit_eq_currency_fz = "currency = {:.4f} * fz^2 + {:.4f} * fz + {:.4f}".format(coeffs_currency_fz[0], coeffs_currency_fz[1], coeffs_currency_fz[2])
+    print("Fitting Equation (x:fz y:currency): {}".format(fit_eq_currency_fz))
 
     # n-th order polynomial fit for x:PWM_ratio y:fz
     coeffs_PWM_ratio_fz = np.polyfit(PWM_ratio, fz, order)
-    fit_eq_PWM_ratio_fz = f"fz = "
+    fit_eq_PWM_ratio_fz = "fz = "
     for i in range(order + 1):
-        fit_eq_PWM_ratio_fz += f"\n{coeffs_PWM_ratio_fz[i]:.4e} * PWM_Ratio_%^{order - i} +"
+        fit_eq_PWM_ratio_fz += "\n{:.4e} * PWM_Ratio_%^{} +".format(coeffs_PWM_ratio_fz[i], order - i)
     print()
-    print(f"Fitting Equation (x:PWM_Ratio_% y:fz): {fit_eq_PWM_ratio_fz}")
+    print("Fitting Equation (x:PWM_Ratio_% y:fz): {}".format(fit_eq_PWM_ratio_fz))
     for i in range(order + 1):
-        print("polynomial{}: {}".format(order - i, pow(10, order - i) * coeffs_PWM_ratio_fz[i]))
+        print("polynomial{}: {:.8f}  # x10^{}".format(order - i, pow(10, order - i) * coeffs_PWM_ratio_fz[i], order -i))
     print()
 
     # n-th order polynomial fit for x:fz y:PWM_ratio
     coeffs_fz_PWM_ratio = np.polyfit(fz, PWM_ratio, order)
-    fit_eq_fz_PWM_ratio = f"PWM_ratio_% = "
+    fit_eq_fz_PWM_ratio = "PWM_ratio_% = "
     for i in range(order + 1):
-        fit_eq_fz_PWM_ratio += f"\n{coeffs_fz_PWM_ratio[i]:.4e} * fz^{order - i} + "
-    print(f"Fitting Equation (x:fz y:PWM_Ratio_%): {fit_eq_fz_PWM_ratio}")
-    print(f"voltage: {set_voltage}")
-    print(f"max_thrust: {np.max(fz):.4f} # N")
+        fit_eq_fz_PWM_ratio += "\n{:.4e} * fz^{} + ".format(coeffs_fz_PWM_ratio[i], order - i)
+    print("Fitting Equation (x:fz y:PWM_Ratio_%): {fit_eq_fz_PWM_ratio}")
+    print("voltage: {}".format(set_voltage))
+    print("max_thrust: {:.4f} # N".format(np.max(fz)))
     for i in range(order + 1):
-        print("polynomial{}: {}  # x10^{}".format(order - i, pow(10, order - i) * coeffs_fz_PWM_ratio[i], order - i))
+        print("polynomial{}: {:.8f}  # x10^{}".format(order - i, pow(10, order - i) * coeffs_fz_PWM_ratio[i], order - i))
     print()
 
     # Create 3x3 subplots


### PR DESCRIPTION
@Li-Jinjie Please review this PR.

### What is this
- added new plot PWM_ratio_% vs fz 
- python2 compatibility

### Details
- enabled to set polynominal order (default is 2)
- add PWM_ratio_% vs fz plot and print function
- removed f-string expression for python2

output
```
$ python scripts/analyze_data.py 10inch_262V_4.txt 0 --order 4 --set_voltage 26.2
Fitting Equation (x:fz y:mz): mz = 0.0149 * fz
Fitting Equation (x:fz y:currency): currency = 0.0293 * fz^2 + 0.4039 * fz + 0.1955

Fitting Equation (x:PWM_Ratio_% y:fz): fz =
-7.4554e-05 * PWM_Ratio_%^4 +
2.1365e-02 * PWM_Ratio_%^3 +
-2.2663e+00 * PWM_Ratio_%^2 +
1.0638e+02 * PWM_Ratio_%^1 +
-1.8702e+03 * PWM_Ratio_%^0 +
polynomial4: -0.74553981  # x10^4
polynomial3: 21.36463036  # x10^3
polynomial2: -226.63254444  # x10^2
polynomial1: 1063.81230575  # x10^1
polynomial0: -1870.22513768  # x10^0

Fitting Equation (x:fz y:PWM_Ratio_%): PWM_ratio_% =
1.7862e-05 * fz^4 +
-1.3577e-05 * fz^3 +
-4.2863e-02 * fz^2 +
1.9200e+00 * fz^1 +
5.5419e+01 * fz^0 +
voltage: 26.2
max_thrust: 28.1106 # N
polynomial4: 0.17862360  # x10^4
polynomial3: -0.01357697  # x10^3
polynomial2: -4.28625784  # x10^2
polynomial1: 19.19985946  # x10^1
polynomial0: 55.41936000  # x10^0
```

Plot axs(0, 2) is added
![Figure_1](https://github.com/user-attachments/assets/3283aaa3-4292-4d6c-a037-def6b8ebe87f)
