### PR TITLE
[Estimation][Rotation][WIP] refactor the rotation calculation from IMU and Mocap/VO with strict SO(3) theory

### DIFF
--- a/aerial_robot_estimation/include/aerial_robot_estimation/sensor/imu.h
+++ b/aerial_robot_estimation/include/aerial_robot_estimation/sensor/imu.h
@@ -78,7 +78,7 @@ namespace sensor_plugin
     double sensor_dt_;
 
     /* imu */
-    tf::Vector3 wz_b_; /* unit z axis of world frame in baselink frame */
+    tf::Vector3 g_b_; /* the *opposite* gravity vector in baselink frame */
     tf::Vector3 omega_; /* the omega both of body frame */
     tf::Vector3 mag_; /* the magnetometer of body frame */
     /* acc */

--- a/aerial_robot_estimation/src/sensor/imu.cpp
+++ b/aerial_robot_estimation/src/sensor/imu.cpp
@@ -48,7 +48,7 @@ namespace sensor_plugin
     sensor_plugin::SensorBase(),
     calib_count_(200),
     acc_b_(0, 0, 0),
-    wz_b_(0, 0, 0),
+    g_b_(0, 0, 0),
     omega_(0, 0, 0),
     mag_(0, 0, 0),
     acc_bias_b_(0, 0, 0),
@@ -102,7 +102,7 @@ namespace sensor_plugin
         acc_b_[i] = imu_msg->acc_data[i]; // baselink frame
         omega_[i] = imu_msg->gyro_data[i];  // baselink frame
         mag_[i] = imu_msg->mag_data[i];  // baselink frame
-        wz_b_[i] = imu_msg->angles[i];  // workaround to avoid the singularity of RPY Euler angles.
+        g_b_[i] = imu_msg->angles[i];  // workaround to avoid the singularity of RPY Euler angles.
       }
 
     estimateProcess();
@@ -124,12 +124,9 @@ namespace sensor_plugin
     tf::Transform cog2baselink_tf;
     tf::transformKDLToTF(robot_model_->getCog2Baselink<KDL::Frame>(), cog2baselink_tf);
 
-    // convert to CoG frame, since in the current system, CoG frame is never being sigular due to RPY euler
-    tf::Vector3 wz_c = cog2baselink_tf.getBasis() * wz_b_;
-    tf::Vector3 cog_euler;
-    cog_euler[0] = atan2(wz_c.y() , wz_c.z());
-    cog_euler[1] = atan2(-wz_c.x() , sqrt(wz_c.y() * wz_c.y() + wz_c.z() * wz_c.z()));
-
+    tf::Vector3 wz_b = g_b_.normalize();
+    tf::Vector3 wx_b = tf::Vector3(0, wz_b.z(), -wz_b.y()); // TODO: change to magnetic one
+    wx_b.normalize();
 
     // 1. egomotion estimate mode
     //  check whether have valid rotation from VO sensor
@@ -141,20 +138,25 @@ namespace sensor_plugin
 
             if (vo_handler->rotValid())
               {
-                tf::Matrix3x3 cog_rot_by_vo = vo_handler->getRawBaselinkTF().getBasis() * cog2baselink_tf.getBasis().inverse();
-                // we replace the yaw angle from the spinal with the value from VO.
-                double r,p,y;
-                cog_rot_by_vo.getRPY(r, p, y);
-                cog_euler[2] = y;
+                tf::Matrix3x3 vo_rot = vo_handler->getRawBaselinkTF().getBasis();
+                // we replace the wx_c with the value from VO.
+                wx_b = vo_rot.transpose() * tf::Vector3(1,0,0);
                 break;
               }
           }
       }
 
-    cog_rot_.at(aerial_robot_estimation::EGOMOTION_ESTIMATE).setRPY(cog_euler[0], cog_euler[1], cog_euler[2]);
-    estimator_->setOrientation(Frame::COG, aerial_robot_estimation::EGOMOTION_ESTIMATE, cog_rot_.at(aerial_robot_estimation::EGOMOTION_ESTIMATE));
-    base_rot_.at(aerial_robot_estimation::EGOMOTION_ESTIMATE) = cog_rot_.at(aerial_robot_estimation::EGOMOTION_ESTIMATE) * cog2baselink_tf.getBasis();
-    estimator_->setOrientation(Frame::BASELINK, aerial_robot_estimation::EGOMOTION_ESTIMATE, base_rot_.at(aerial_robot_estimation::EGOMOTION_ESTIMATE));
+    tf::Vector3 wy_b = wz_b.cross(wx_b);
+    wy_b.normalize();
+    tf::Matrix3x3 rot(wx_b.x(), wx_b.y(), wx_b.z(),
+                      wy_b.x(), wy_b.y(), wy_b.z(),
+                      wz_b.x(), wz_b.y(), wz_b.z());
+    base_rot_.at(aerial_robot_estimation::EGOMOTION_ESTIMATE) = rot;
+    estimator_->setOrientation(Frame::BASELINK, aerial_robot_estimation::EGOMOTION_ESTIMATE, rot);
+
+    tf::Matrix3x3 rot_c = rot * cog2baselink_tf.getBasis().transpose();
+    cog_rot_.at(aerial_robot_estimation::EGOMOTION_ESTIMATE) = rot_c;
+    estimator_->setOrientation(Frame::COG, aerial_robot_estimation::EGOMOTION_ESTIMATE, rot_c);
 
     estimator_->setAngularVel(Frame::COG, aerial_robot_estimation::EGOMOTION_ESTIMATE, cog2baselink_tf.getBasis() * omega_);
     estimator_->setAngularVel(Frame::BASELINK, aerial_robot_estimation::EGOMOTION_ESTIMATE, omega_);
@@ -162,15 +164,21 @@ namespace sensor_plugin
     // 2. experiment estimate mode
     if(estimator_->getStateStatus(State::CoG::Rot, aerial_robot_estimation::GROUND_TRUTH))
       {
-        tf::Matrix3x3 gt_cog_rot = estimator_->getOrientation(Frame::COG, aerial_robot_estimation::GROUND_TRUTH);
-        double r,p,y;
-        gt_cog_rot.getRPY(r, p, y);
-        cog_euler[2] = y;
+        tf::Matrix3x3 gt_rot = estimator_->getOrientation(Frame::BASELINK, aerial_robot_estimation::GROUND_TRUTH);
+        wx_b = gt_rot.transpose() * tf::Vector3(1,0,0);
       }
-    cog_rot_.at(aerial_robot_estimation::EXPERIMENT_ESTIMATE).setRPY(cog_euler[0], cog_euler[1], cog_euler[2]);
-    estimator_->setOrientation(Frame::COG, aerial_robot_estimation::EXPERIMENT_ESTIMATE, cog_rot_.at(aerial_robot_estimation::EXPERIMENT_ESTIMATE));
-    base_rot_.at(aerial_robot_estimation::EXPERIMENT_ESTIMATE) = cog_rot_.at(aerial_robot_estimation::EXPERIMENT_ESTIMATE) * cog2baselink_tf.getBasis();
-    estimator_->setOrientation(Frame::BASELINK, aerial_robot_estimation::EXPERIMENT_ESTIMATE, base_rot_.at(aerial_robot_estimation::EXPERIMENT_ESTIMATE));
+
+    wy_b = wz_b.cross(wx_b);
+    wy_b.normalize();
+    rot = tf::Matrix3x3(wx_b.x(), wx_b.y(), wx_b.z(),
+                        wy_b.x(), wy_b.y(), wy_b.z(),
+                        wz_b.x(), wz_b.y(), wz_b.z());
+    base_rot_.at(aerial_robot_estimation::EXPERIMENT_ESTIMATE) = rot;
+    estimator_->setOrientation(Frame::BASELINK, aerial_robot_estimation::EXPERIMENT_ESTIMATE, rot);
+
+    rot_c = rot * cog2baselink_tf.getBasis().transpose();
+    cog_rot_.at(aerial_robot_estimation::EXPERIMENT_ESTIMATE) = rot_c;
+    estimator_->setOrientation(Frame::COG, aerial_robot_estimation::EXPERIMENT_ESTIMATE, rot_c);
 
     estimator_->setAngularVel(Frame::COG, aerial_robot_estimation::EXPERIMENT_ESTIMATE, cog2baselink_tf.getBasis() * omega_);
     estimator_->setAngularVel(Frame::BASELINK, aerial_robot_estimation::EXPERIMENT_ESTIMATE, omega_);

--- a/robots/beetle/src/sensor/imu.cpp
+++ b/robots/beetle/src/sensor/imu.cpp
@@ -76,7 +76,7 @@ namespace sensor_plugin
           }
 
         acc_b_[i] = imu_msg->acc_data[i];
-        wz_b_[i] = imu_msg->angles[i];
+        g_b_[i] = imu_msg->angles[i];
         omega_[i] = imu_msg->gyro_data[i];
         mag_[i] = imu_msg->mag_data[i];
       }

--- a/robots/dragon/src/sensor/imu.cpp
+++ b/robots/dragon/src/sensor/imu.cpp
@@ -76,7 +76,7 @@ namespace sensor_plugin
           }
 
         acc_b_[i] = imu_msg->acc_data[i];
-        wz_b_[i] = imu_msg->angles[i];
+        g_b_[i] = imu_msg->angles[i];
         omega_[i] = imu_msg->gyro_data[i];
         mag_[i] = imu_msg->mag_data[i];
       }


### PR DESCRIPTION
### What is this

Refactor the SO(3) rotation of baselink from IMU (and Mocap, or other sensors).

### Details

Strict SO(3) theory deponeds on the calculation of 
- `wz_b`: the z axis of world frame w.r.t. the baselink frame, this is directly calculated from gravity
- `wx_b`: the x axis of world frame w.r.t. the baselink frame, this can be obtained from magnetometer/VIO/Mocap
- `wy_b`: the y axis of world frame w.r.t. the baselink frame, this can be obtained by the cross product of `wx_b` and `wz_b`.

Then, `rot`, which is the rotation matrix of the baselink frame w.r.t. the world frame, can be easily obtaind the above three axes.

### TODO

The magetometer value is not used, which should be considered as the default reference to calcualte `wx_b`
