### PR TITLE
Fix the bug caused by PR #31 and commit 6b59c9

### DIFF
--- a/aerial_robot_control/src/nmpc/tilt_mt_servo_nmpc_controller.cpp
+++ b/aerial_robot_control/src/nmpc/tilt_mt_servo_nmpc_controller.cpp
@@ -509,6 +509,8 @@ void nmpc::TiltMtServoNMPC::prepareNMPCRef()
       navigator_->setTargetOmegaX(0.0);
       navigator_->setTargetOmegaY(0.0);
       navigator_->setTargetOmegaZ(0.0);
+
+      last_traj_msg_.points.clear();  // every time end the traj tracking, clear the traj msg
     }
 
     return;
@@ -863,7 +865,7 @@ void nmpc::TiltMtServoNMPC::callbackSetRefTraj(const trajectory_msgs::MultiDOFJo
   /* For set-point regulation, if the traj planner sends the same traj, we can skip the calculation of allocation. */
   // check if two trajectories are the same
   int max_same_idx = 0;
-  if (last_traj_msg_.points.size() != 0)  // check if the last trajectory is empty
+  if (!last_traj_msg_.points.empty())  // check if the last trajectory is empty
   {
     for (int i = 0; i < msg->points.size(); i++)  // only check the first NN points
     {

--- a/aerial_robot_control/src/nmpc/tilt_mt_servo_nmpc_controller.cpp
+++ b/aerial_robot_control/src/nmpc/tilt_mt_servo_nmpc_controller.cpp
@@ -217,6 +217,7 @@ void nmpc::TiltMtServoNMPC::initNMPCConstraints()
   getParam<double>(nmpc_nh, "a_max", servo_angle_max_, 3.1416);
   getParam<double>(nmpc_nh, "a_min", servo_angle_min_, -3.1416);
 
+  // lbx and ubx
   std::vector<int> idxbx = mpc_solver_ptr_->getConstraintsIdxbx();
   std::vector<int> idxbx_desired = { 3, 4, 5, 10, 11, 12 };
   idxbx_desired.resize(6 + joint_num_);
@@ -241,6 +242,17 @@ void nmpc::TiltMtServoNMPC::initNMPCConstraints()
   mpc_solver_ptr_->setConstraintsLbx(lbx);
   mpc_solver_ptr_->setConstraintsUbx(ubx);
 
+  // lbxe and ubxe
+  std::vector<int> idxbxe = mpc_solver_ptr_->getConstraintsIdxbxe();
+  std::vector<int> idxbxe_desired = idxbx_desired;
+  if (idxbxe.size() != idxbxe_desired.size() || !std::equal(idxbxe.begin(), idxbxe.end(), idxbxe_desired.begin()))
+  {
+    ROS_ERROR("idxbx_end is not equal to idxbx_end_desired, we cannot set constraints lbxe and ubxe!");
+  }
+  mpc_solver_ptr_->setConstraintsLbxe(lbx);
+  mpc_solver_ptr_->setConstraintsUbxe(ubx);
+
+  // lbu and ubu
   std::vector<int> idxbu = mpc_solver_ptr_->getConstraintsIdxbu();
   std::vector<int> idxbu_desired(motor_num_ + joint_num_);
   for (int i = 0; i < motor_num_; i++)

--- a/aerial_robot_control/src/nmpc/tilt_mt_servo_thrust_dist_nmpc_controller.cpp
+++ b/aerial_robot_control/src/nmpc/tilt_mt_servo_thrust_dist_nmpc_controller.cpp
@@ -88,6 +88,7 @@ void nmpc::TiltMtServoThrustDistNMPC::initNMPCConstraints()
   getParam<double>(nmpc_nh, "a_max", servo_angle_max, 3.1416);
   getParam<double>(nmpc_nh, "a_min", servo_angle_min, -3.1416);
 
+  // lbx and ubx
   std::vector<int> idxbx = mpc_solver_ptr_->getConstraintsIdxbx();
   std::vector<int> idxbx_desired = { 3, 4, 5, 10, 11, 12 };
   idxbx_desired.resize(6 + joint_num_ + motor_num_);
@@ -122,6 +123,17 @@ void nmpc::TiltMtServoThrustDistNMPC::initNMPCConstraints()
   mpc_solver_ptr_->setConstraintsLbx(lbx);
   mpc_solver_ptr_->setConstraintsUbx(ubx);
 
+  // lbxe and ubxe
+  std::vector<int> idxbxe = mpc_solver_ptr_->getConstraintsIdxbxe();
+  std::vector<int> idxbxe_desired = idxbx_desired;
+  if (idxbxe.size() != idxbxe_desired.size() || !std::equal(idxbxe.begin(), idxbxe.end(), idxbxe_desired.begin()))
+  {
+    ROS_ERROR("idxbx_end is not equal to idxbx_end_desired, we cannot set constraints lbxe and ubxe!");
+  }
+  mpc_solver_ptr_->setConstraintsLbxe(lbx);
+  mpc_solver_ptr_->setConstraintsUbxe(ubx);
+
+  // lbu and ubu
   std::vector<int> idxbu = mpc_solver_ptr_->getConstraintsIdxbu();
   std::vector<int> idxbu_desired(motor_num_ + joint_num_);
   for (int i = 0; i < motor_num_; i++)

--- a/aerial_robot_planning/scripts/pub_mpc_joint_traj.py
+++ b/aerial_robot_planning/scripts/pub_mpc_joint_traj.py
@@ -137,6 +137,11 @@ class MPCSinglePtPub(MPCPubJointTraj):
                  pos_tol=0.2, ang_tol=0.3, vel_tol=0.1, rate_tol=0.1):
         super().__init__(robot_name=robot_name, node_name="mpc_single_pt_pub", is_calc_rmse=False)
         self.target_pose = target_pose
+        rospy.loginfo(f"{self.namespace}/{self.node_name}: \n"
+                      f"Target pose: x {self.target_pose.position.x}, "
+                      f"y {self.target_pose.position.y}, z {self.target_pose.position.z}; "
+                      f"qw {self.target_pose.orientation.w}, qx {self.target_pose.orientation.x}, "
+                      f"qy {self.target_pose.orientation.y}, qz {self.target_pose.orientation.z}")
 
         # Tolerances for considering the target "reached"
         self.pos_tol = pos_tol  # e.g. 0.1 m


### PR DESCRIPTION
### What is this

Bug by PR #31: forget to set end constraints.
Bug by commit 6b59c9: cannot track some pred_xu traj for twice. For example, v=2_3 traj.

### Details

After fixing this bug, the tracking result for scvx_traj_max_v=2_3.csv is improved.

Before:
pos_err_norm = 0.324 m,
pos_err = 0.168 m, 0.264 m, 0.085 m,
ang_err_norm = 2.368 deg,
ang_err = 1.806 deg, 0.736 deg, 1.344 deg

Now:
pos_err_norm = 0.312 m,
pos_err = 0.162 m, 0.252 m, 0.088 m,
ang_err_norm = 2.332 deg,
ang_err = 1.836 deg, 0.724 deg, 1.242 deg