### PR TITLE
Redfined 'overwrite' flag in rh_base

### DIFF
--- a/aerial_robot_control/scripts/nmpc/archive/tilt_qd_no_servo_ac_cost.py
+++ b/aerial_robot_control/scripts/nmpc/archive/tilt_qd_no_servo_ac_cost.py
@@ -1,8 +1,11 @@
 #!/usr/bin/env python
 # -*- encoding: ascii -*-
+import os, sys
 import numpy as np
 import casadi as ca
-from qd_nmpc_base import QDNMPCBase
+
+sys.path.append(os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))    # Add parent's parent directory to path to allow relative imports
+from tilt_qd.qd_nmpc_base import QDNMPCBase
 import archive.phys_param_beetle_art as phys_art
 
 
@@ -172,7 +175,7 @@ class NMPCTiltQdNoServoAcCost(QDNMPCBase):
 
 
 if __name__ == "__main__":
-    overwrite = False
+    overwrite = True
     nmpc = NMPCTiltQdNoServoAcCost(overwrite)
 
     acados_ocp_solver = nmpc.get_ocp_solver()

--- a/aerial_robot_control/scripts/nmpc/archive/tilt_qd_servo_drag_w_dist.py
+++ b/aerial_robot_control/scripts/nmpc/archive/tilt_qd_servo_drag_w_dist.py
@@ -482,7 +482,7 @@ class NMPCTiltQdServoDragDist(RecedingHorizonBase):
 
 
 if __name__ == "__main__":
-    overwrite = False
+    overwrite = True
     nmpc = NMPCTiltQdServoDragDist(overwrite)
 
     acados_ocp_solver = nmpc.get_ocp_solver()

--- a/aerial_robot_control/scripts/nmpc/fix_qd/fix_qd_angvel_out.py
+++ b/aerial_robot_control/scripts/nmpc/fix_qd/fix_qd_angvel_out.py
@@ -216,7 +216,7 @@ class NMPCFixQdAngvelOut(RecedingHorizonBase):
 
 if __name__ == "__main__":
     # Call controller class to generate c code
-    overwrite = False
+    overwrite = True
     nmpc = NMPCFixQdAngvelOut(overwrite)
 
     print("Successfully initialized acados OCP solver: ", nmpc.get_ocp_solver())

--- a/aerial_robot_control/scripts/nmpc/fix_qd/fix_qd_thrust_out.py
+++ b/aerial_robot_control/scripts/nmpc/fix_qd/fix_qd_thrust_out.py
@@ -136,7 +136,7 @@ class NMPCFixQdThrustOut(QDNMPCBase):
 
 if __name__ == "__main__":
     # Call controller class to generate c code
-    overwrite = False
+    overwrite = True
     nmpc = NMPCFixQdThrustOut(overwrite)
 
     print("Successfully initialized acados OCP solver: ", nmpc.get_ocp_solver())

--- a/aerial_robot_control/scripts/nmpc/mhe/mhe_kinematics.py
+++ b/aerial_robot_control/scripts/nmpc/mhe/mhe_kinematics.py
@@ -206,7 +206,7 @@ class MHEKinematics(RecedingHorizonBase):
 
 if __name__ == "__main__":
     # Call MHE class to generate c code
-    overwrite = False
+    overwrite = True
     mhe = MHEKinematics(overwrite)
 
     acados_ocp_solver = mhe.get_ocp_solver()

--- a/aerial_robot_control/scripts/nmpc/rh_base.py
+++ b/aerial_robot_control/scripts/nmpc/rh_base.py
@@ -94,10 +94,10 @@ def safe_mkdir_recursive(directory, overwrite: bool = False):
         if os.path.exists(directory):
             try:
                 # Only remove auto-generated files, not the directory itself
-                for _, dirs, files in os.walk(directory, topdown=False):
+                for _, dirs, files in os.walk(directory):
                     for file in files:
                         file_path = os.path.join(directory, file)
-                        if os.path.isfile(file_path) and not file_path.endswith("solver.h") and not file_path.endswith("controller.h"):
+                        if os.path.isfile(file_path) and not (file_path.endswith("solver.h") or file_path.endswith("controller.h")):
                             os.remove(file_path)
                     for dir in dirs:
                         dir_path = os.path.join(directory, dir)
@@ -117,14 +117,26 @@ def safe_mkdir_recursive(directory, overwrite: bool = False):
                 # Check if directory unexpectedly already exists (may happen if multiple
                 # processes try to read/create it at the same time)
                 if e.errno == errno.EEXIST and os.path.isdir(directory):
-                    # Directory already exists
-                    print(f"Directory {directory} already exists. Set 'overwrite' to True to overwrite it.")
-                    # Skip further processing and exit program
-                    sys.exit()
+                    pass
                 else:
                     raise e
         else:
-            # Directory already exists
-            print(f"Directory {directory} already exists. Set 'overwrite' to True to overwrite it.")
-            # Skip further processing and exit program
-            sys.exit()
+            # Check if directory only contains non-auto-generated files
+            empty = True
+            for _, dirs, files in os.walk(directory):
+                for file in files:
+                    file_path = os.path.join(directory, file)
+                    if os.path.isfile(file_path) and not (file_path.endswith("solver.h") or file_path.endswith("controller.h")):
+                        empty = False
+                for dir in dirs:
+                    dir_path = os.path.join(directory, dir)
+                    if os.path.isdir(dir_path):
+                        empty = False
+            if not empty:
+                # Directory already exists and contains controller files
+                print(f"Directory {directory} already exists. Set 'overwrite' to True to overwrite it.")
+                # Skip further processing and exit program
+                sys.exit()
+            else:
+                # Directory exists but not auto-generated files
+                pass

--- a/aerial_robot_control/scripts/nmpc/rh_base.py
+++ b/aerial_robot_control/scripts/nmpc/rh_base.py
@@ -78,30 +78,53 @@ class RecedingHorizonBase(ABC):
         # Make a directory for generating cpp files of the acados model and solver
         # 'method' is either "nmpc" or "wrench_est"
         rospack = rospkg.RosPack()
-        folder_path = os.path.join(rospack.get_path("aerial_robot_control"), "include", "aerial_robot_control", method,
-                                   model_name)
+        folder_path = os.path.join(rospack.get_path("aerial_robot_control"), "include", "aerial_robot_control", 
+                                   method, model_name)
         safe_mkdir_recursive(folder_path, overwrite)
         os.chdir(folder_path)   # Change working directory to the model folder (also affects inheritted classes)
 
-def safe_mkdir_recursive(directory, overwrite=False):
-    if not os.path.exists(directory):
-        try:
-            os.makedirs(directory)
-        except OSError as exc:
-            if exc.errno == errno.EEXIST and os.path.isdir(directory):
-                pass
-            else:
-                raise
-    else:
-        if overwrite:
+def safe_mkdir_recursive(directory, overwrite: bool = False):
+    """
+    Safely create a directory recursively, optionally overwriting it if it already exists.
+    :param directory: Absoulte path of the directory to create.
+    :param overwrite: If True, overwrite the directory if it already exists. Default: False
+    """
+    if overwrite:
+        # Delete existing directory
+        if os.path.exists(directory):
             try:
-                shutil.rmtree(directory)
-                try:
-                    os.makedirs(directory)
-                except OSError as exc:
-                    if exc.errno == errno.EEXIST and os.path.isdir(directory):
-                        pass
-                    else:
-                        raise
-            except:
-                print("Error while removing directory {}".format(directory))
+                # Only remove auto-generated files, not the directory itself
+                for _, dirs, files in os.walk(directory, topdown=False):
+                    for file in files:
+                        file_path = os.path.join(directory, file)
+                        if os.path.isfile(file_path) and not file_path.endswith("solver.h") and not file_path.endswith("controller.h"):
+                            os.remove(file_path)
+                    for dir in dirs:
+                        dir_path = os.path.join(directory, dir)
+                        if os.path.isdir(dir_path):
+                            shutil.rmtree(dir_path)
+            except Exception as e:
+                print(f"Error while removing directory {directory}:")
+                raise e
+        # Create new directory
+        os.makedirs(directory, exist_ok=True)
+    else:
+        if not os.path.exists(directory):
+            try:
+                # Create new directory
+                os.makedirs(directory)
+            except OSError as e:
+                # Check if directory unexpectedly already exists (may happen if multiple
+                # processes try to read/create it at the same time)
+                if e.errno == errno.EEXIST and os.path.isdir(directory):
+                    # Directory already exists
+                    print(f"Directory {directory} already exists. Set 'overwrite' to True to overwrite it.")
+                    # Skip further processing and exit program
+                    sys.exit()
+                else:
+                    raise e
+        else:
+            # Directory already exists
+            print(f"Directory {directory} already exists. Set 'overwrite' to True to overwrite it.")
+            # Skip further processing and exit program
+            sys.exit()

--- a/aerial_robot_control/scripts/nmpc/tilt_bi/tilt_bi_2ord_servo.py
+++ b/aerial_robot_control/scripts/nmpc/tilt_bi/tilt_bi_2ord_servo.py
@@ -438,7 +438,7 @@ class NMPCTiltBi2OrdServo(RecedingHorizonBase):
         return AcadosSimSolver(acados_sim, json_file=ocp_model.name + "_acados_sim.json", build=is_build)
 
 if __name__ == "__main__":
-    overwrite = False
+    overwrite = True
     nmpc = NMPCTiltBi2OrdServo(overwrite)
 
     acados_ocp_solver = nmpc.get_ocp_solver()

--- a/aerial_robot_control/scripts/nmpc/tilt_bi/tilt_bi_servo.py
+++ b/aerial_robot_control/scripts/nmpc/tilt_bi/tilt_bi_servo.py
@@ -400,7 +400,7 @@ class NMPCTiltBiServo(RecedingHorizonBase):
 
 
 if __name__ == "__main__":
-    overwrite = False
+    overwrite = True
     nmpc = NMPCTiltBiServo(overwrite)
 
     acados_ocp_solver = nmpc.get_ocp_solver()

--- a/aerial_robot_control/scripts/nmpc/tilt_qd/mhe_wrench_est_acc_mom.py
+++ b/aerial_robot_control/scripts/nmpc/tilt_qd/mhe_wrench_est_acc_mom.py
@@ -9,11 +9,11 @@ from tilt_qd.phys_param_beetle_omni import *
 
 
 class MHEWrenchEstAccMom(QDMHEBase):
-    def __init__(self):
+    def __init__(self, overwrite: bool = False):
         # Read parameters from configuration file in the robot's package
         self.read_params("controller", "mhe", "beetle_omni", "WrenchEstMHEAccMom.yaml")
 
-        super(MHEWrenchEstAccMom, self).__init__()
+        super().__init__(overwrite)
 
     def create_acados_model(self) -> AcadosModel:
         # Model name
@@ -119,7 +119,8 @@ class MHEWrenchEstAccMom(QDMHEBase):
         
 
 if __name__ == "__main__":
-    mhe = MHEWrenchEstAccMom()
+    overwrite = True
+    mhe = MHEWrenchEstAccMom(overwrite)
 
     acados_ocp_solver = mhe.get_ocp_solver()
     print("Successfully initialized acados ocp: ", acados_ocp_solver.acados_ocp)

--- a/aerial_robot_control/scripts/nmpc/tilt_qd/mhe_wrench_est_imu_act.py
+++ b/aerial_robot_control/scripts/nmpc/tilt_qd/mhe_wrench_est_imu_act.py
@@ -9,11 +9,11 @@ from tilt_qd.phys_param_beetle_omni import *
 
 
 class MHEWrenchEstIMUAct(QDMHEBase):
-    def __init__(self):
+    def __init__(self, overwrite: bool = False):
         # Read parameters from configuration file in the robot's package
         self.read_params("controller", "mhe", "beetle_omni", "WrenchEstMHEImuActuator.yaml")
 
-        super(MHEWrenchEstIMUAct, self).__init__()
+        super().__init__(overwrite)
 
     def create_acados_model(self) -> AcadosModel:
         # Model name
@@ -242,7 +242,8 @@ class MHEWrenchEstIMUAct(QDMHEBase):
 
 
 if __name__ == "__main__":
-    mhe = MHEWrenchEstIMUAct()
+    overwrite = True
+    mhe = MHEWrenchEstIMUAct(overwrite)
 
     acados_ocp_solver = mhe.get_ocp_solver()
     print("Successfully initialized acados ocp: ", acados_ocp_solver.acados_ocp)

--- a/aerial_robot_control/scripts/nmpc/tilt_qd/mhe_wrench_est_momentum.py
+++ b/aerial_robot_control/scripts/nmpc/tilt_qd/mhe_wrench_est_momentum.py
@@ -9,11 +9,11 @@ from tilt_qd.phys_param_beetle_omni import *
 
 
 class MHEWrenchEstMomentum(QDMHEBase):
-    def __init__(self):
+    def __init__(self, overwrite: bool = False):
         # Read parameters from configuration file in the robot's package
         self.read_params("controller", "mhe", "beetle_omni", "WrenchEstMHEMomentum.yaml")
 
-        super(MHEWrenchEstMomentum, self).__init__()
+        super().__init__(overwrite)
 
     def create_acados_model(self) -> AcadosModel:
         # Model name
@@ -127,7 +127,8 @@ class MHEWrenchEstMomentum(QDMHEBase):
 
 
 if __name__ == "__main__":
-    mhe = MHEWrenchEstMomentum()
+    overwrite = True
+    mhe = MHEWrenchEstMomentum(overwrite)
 
     acados_ocp_solver = mhe.get_ocp_solver()
     print("Successfully initialized acados ocp: ", acados_ocp_solver.acados_ocp)

--- a/aerial_robot_control/scripts/nmpc/tilt_qd/mhe_wrench_est_new_meas.py
+++ b/aerial_robot_control/scripts/nmpc/tilt_qd/mhe_wrench_est_new_meas.py
@@ -9,11 +9,11 @@ from tilt_qd.phys_param_beetle_omni import *
 
 
 class MHEVelDynIMU(QDMHEBase):
-    def __init__(self):
+    def __init__(self, overwrite: bool = False):
         # Read parameters from configuration file in the robot's package
         self.read_params("controller", "mhe", "beetle_omni", "WrenchEstMHEAccMom2.yaml")
 
-        super(MHEVelDynIMU, self).__init__()
+        super().__init__(overwrite)
 
     def create_acados_model(self) -> AcadosModel:
         # Model name
@@ -144,7 +144,8 @@ class MHEVelDynIMU(QDMHEBase):
 
 
 if __name__ == "__main__":
-    mhe = MHEVelDynIMU()
+    overwrite = True
+    mhe = MHEVelDynIMU(overwrite)
 
     acados_ocp_solver = mhe.get_ocp_solver()
     print("Successfully initialized acados ocp: ", acados_ocp_solver.acados_ocp)

--- a/aerial_robot_control/scripts/nmpc/tilt_qd/qd_nmpc_base.py
+++ b/aerial_robot_control/scripts/nmpc/tilt_qd/qd_nmpc_base.py
@@ -81,20 +81,20 @@ class QDNMPCBase(RecedingHorizonBase):
         # Standard state-space (Note: store in self to access for cost function in child controller class)
         self.x = ca.SX.sym("x")  # Position
         self.y = ca.SX.sym("y")
-        self.z = ca.SX.sym("z");
+        self.z = ca.SX.sym("z")
         self.p = ca.vertcat(self.x, self.y, self.z)
         self.vx = ca.SX.sym("vx")  # Linear velocity
         self.vy = ca.SX.sym("vy")
-        self.vz = ca.SX.sym("vz");
+        self.vz = ca.SX.sym("vz")
         self.v = ca.vertcat(self.vx, self.vy, self.vz)
         self.qw = ca.SX.sym("qw")  # Quaternions
         self.qx = ca.SX.sym("qx")
         self.qy = ca.SX.sym("qy")
-        self.qz = ca.SX.sym("qz");
+        self.qz = ca.SX.sym("qz")
         self.q = ca.vertcat(self.qw, self.qx, self.qy, self.qz)
         self.wx = ca.SX.sym("wx")  # Angular velocity
         self.wy = ca.SX.sym("wy")
-        self.wz = ca.SX.sym("wz");
+        self.wz = ca.SX.sym("wz")
         self.w = ca.vertcat(self.wx, self.wy, self.wz)
         states = ca.vertcat(self.p, self.v, self.q, self.w)
 
@@ -261,14 +261,14 @@ class QDNMPCBase(RecedingHorizonBase):
             # If servo dynamics are modeled, use angle state.
             # Else use angle control which is then assumed to be equal to the angle state at all times.
             if self.include_servo_model:
-                a1 = self.a1s;
-                a2 = self.a2s;
-                a3 = self.a3s;
+                a1 = self.a1s
+                a2 = self.a2s
+                a3 = self.a3s
                 a4 = self.a4s
             else:
-                a1 = self.a1c;
-                a2 = self.a2c;
-                a3 = self.a3c;
+                a1 = self.a1c
+                a2 = self.a2c
+                a3 = self.a3c
                 a4 = self.a4c
 
             rot_e1r1 = ca.vertcat(
@@ -284,23 +284,23 @@ class QDNMPCBase(RecedingHorizonBase):
                 ca.horzcat(1, 0, 0), ca.horzcat(0, ca.cos(a4), -ca.sin(a4)), ca.horzcat(0, ca.sin(a4), ca.cos(a4))
             )
         else:
-            rot_e1r1 = ca.SX.eye(3);
-            rot_e2r2 = ca.SX.eye(3);
-            rot_e3r3 = ca.SX.eye(3);
+            rot_e1r1 = ca.SX.eye(3)
+            rot_e2r2 = ca.SX.eye(3)
+            rot_e3r3 = ca.SX.eye(3)
             rot_e4r4 = ca.SX.eye(3)
 
         # Wrench in Rotor frame
         # If rotor dynamics are modeled, explicitly use thrust state as force.
         # Else use thrust control which is then assumed to be equal to the thrust state at all times.
         if self.include_thrust_model:
-            ft1 = self.ft1s;
-            ft2 = self.ft2s;
-            ft3 = self.ft3s;
+            ft1 = self.ft1s
+            ft2 = self.ft2s
+            ft3 = self.ft3s
             ft4 = self.ft4s
         else:
-            ft1 = self.ft1c;
-            ft2 = self.ft2c;
-            ft3 = self.ft3c;
+            ft1 = self.ft1c
+            ft2 = self.ft2c
+            ft3 = self.ft3c
             ft4 = self.ft4c
 
         ft_r1 = ca.vertcat(0, 0, ft1)

--- a/aerial_robot_control/scripts/nmpc/tilt_qd/tilt_qd_no_servo.py
+++ b/aerial_robot_control/scripts/nmpc/tilt_qd/tilt_qd_no_servo.py
@@ -146,7 +146,7 @@ class NMPCTiltQdNoServo(QDNMPCBase):
 
 
 if __name__ == "__main__":
-    overwrite = False
+    overwrite = True
     nmpc = NMPCTiltQdNoServo(overwrite)
 
     acados_ocp_solver = nmpc.get_ocp_solver()

--- a/aerial_robot_control/scripts/nmpc/tilt_qd/tilt_qd_servo.py
+++ b/aerial_robot_control/scripts/nmpc/tilt_qd/tilt_qd_servo.py
@@ -150,7 +150,7 @@ class NMPCTiltQdServo(QDNMPCBase):
 
 
 if __name__ == "__main__":
-    overwrite = False
+    overwrite = True
     nmpc = NMPCTiltQdServo(overwrite)
 
     acados_ocp_solver = nmpc.get_ocp_solver()

--- a/aerial_robot_control/scripts/nmpc/tilt_qd/tilt_qd_servo_diff.py
+++ b/aerial_robot_control/scripts/nmpc/tilt_qd/tilt_qd_servo_diff.py
@@ -150,7 +150,8 @@ class NMPCTiltQdServoDiff(QDNMPCBase):
     
 
 if __name__ == "__main__":
-    nmpc = NMPCTiltQdServoDiff()
+    overwrite = True
+    nmpc = NMPCTiltQdServoDiff(overwrite)
 
     acados_ocp_solver = nmpc.get_ocp_solver()
     print("Successfully initialized acados ocp: ", acados_ocp_solver.acados_ocp)

--- a/aerial_robot_control/scripts/nmpc/tilt_qd/tilt_qd_servo_dist.py
+++ b/aerial_robot_control/scripts/nmpc/tilt_qd/tilt_qd_servo_dist.py
@@ -160,7 +160,7 @@ class NMPCTiltQdServoDist(QDNMPCBase):
 
 
 if __name__ == "__main__":
-    overwrite = False
+    overwrite = True
     nmpc = NMPCTiltQdServoDist(overwrite)
 
     acados_ocp_solver = nmpc.get_ocp_solver()

--- a/aerial_robot_control/scripts/nmpc/tilt_qd/tilt_qd_servo_dist_imp.py
+++ b/aerial_robot_control/scripts/nmpc/tilt_qd/tilt_qd_servo_dist_imp.py
@@ -211,7 +211,7 @@ class NMPCTiltQdServoImpedance(QDNMPCBase):
 
 
 if __name__ == "__main__":
-    overwrite = False
+    overwrite = True
     nmpc = NMPCTiltQdServoImpedance(overwrite)
 
     acados_ocp_solver = nmpc.get_ocp_solver()

--- a/aerial_robot_control/scripts/nmpc/tilt_qd/tilt_qd_servo_thrust.py
+++ b/aerial_robot_control/scripts/nmpc/tilt_qd/tilt_qd_servo_thrust.py
@@ -155,7 +155,7 @@ class NMPCTiltQdServoThrust(QDNMPCBase):
 
 
 if __name__ == "__main__":
-    overwrite = False
+    overwrite = True
     nmpc = NMPCTiltQdServoThrust(overwrite)
 
     acados_ocp_solver = nmpc.get_ocp_solver()

--- a/aerial_robot_control/scripts/nmpc/tilt_qd/tilt_qd_servo_thrust_dist.py
+++ b/aerial_robot_control/scripts/nmpc/tilt_qd/tilt_qd_servo_thrust_dist.py
@@ -169,7 +169,7 @@ class NMPCTiltQdServoThrustDist(QDNMPCBase):
 
 
 if __name__ == "__main__":
-    overwrite = False
+    overwrite = True
     nmpc = NMPCTiltQdServoThrustDist(overwrite)
 
     acados_ocp_solver = nmpc.get_ocp_solver()

--- a/aerial_robot_control/scripts/nmpc/tilt_qd/tilt_qd_servo_thrust_dist_imp.py
+++ b/aerial_robot_control/scripts/nmpc/tilt_qd/tilt_qd_servo_thrust_dist_imp.py
@@ -217,7 +217,7 @@ class NMPCTiltQdServoThrustImpedance(QDNMPCBase):
 
 
 if __name__ == "__main__":
-    overwrite = False
+    overwrite = True
     nmpc = NMPCTiltQdServoThrustImpedance(overwrite)
 
     acados_ocp_solver = nmpc.get_ocp_solver()

--- a/aerial_robot_control/scripts/nmpc/tilt_qd/tilt_qd_thrust.py
+++ b/aerial_robot_control/scripts/nmpc/tilt_qd/tilt_qd_thrust.py
@@ -160,7 +160,7 @@ class NMPCTiltQdThrust(QDNMPCBase):
 
 
 if __name__ == "__main__":
-    overwrite = False
+    overwrite = True
     nmpc = NMPCTiltQdThrust(overwrite)
 
     acados_ocp_solver = nmpc.get_ocp_solver()

--- a/aerial_robot_control/scripts/nmpc/tilt_tri/tilt_tri_servo.py
+++ b/aerial_robot_control/scripts/nmpc/tilt_tri/tilt_tri_servo.py
@@ -425,7 +425,7 @@ class NMPCTiltTriServo(RecedingHorizonBase):
 
 
 if __name__ == "__main__":
-    overwrite = False
+    overwrite = True
     nmpc = NMPCTiltTriServo(overwrite)
 
     acados_ocp_solver = nmpc.get_ocp_solver()

--- a/aerial_robot_control/scripts/nmpc/tilt_tri/tilt_tri_servo_dist.py
+++ b/aerial_robot_control/scripts/nmpc/tilt_tri/tilt_tri_servo_dist.py
@@ -422,7 +422,7 @@ class NMPCTiltTriServoDist(RecedingHorizonBase):
 
 
 if __name__ == "__main__":
-    overwrite = False
+    overwrite = True
     nmpc = NMPCTiltTriServoDist(overwrite)
 
     acados_ocp_solver = nmpc.get_ocp_solver()


### PR DESCRIPTION
### What is this

Redefined what 'overwrite' means: True deletes all auto-generated files in '/include'. False terminates program if already existing files for this controller are found

### Details

- The logic for handling the case for finding existing files in aerial_robot_control/include/aerial_robot_control/nmpc is revised. Now for overwrite=True we check if there are files/dirs except for nmpc_controller.h, nmpc_solver.h and nsim_solver.h (which are not written by hand to be handled in MPC plugin).
- For overwrite=False we only check if there are any files that are not the manual created files. If yes, we terminate the program. If there are only these files, we continue.