### PR TITLE
[Spinal][DSHOT] Support Dshot for AM32 esc

### DIFF
--- a/aerial_robot_nerve/spinal/mcu_project/boards/stm32H7/Src/main.c
+++ b/aerial_robot_nerve/spinal/mcu_project/boards/stm32H7/Src/main.c
@@ -259,7 +259,7 @@ int main(void)
   estimator_.init(&imu_, &baro_, NULL, &nh_);
 #endif
 
-  dshot_.init(DSHOT600, &htim1, TIM_CHANNEL_1, &htim1, TIM_CHANNEL_2, &htim1, TIM_CHANNEL_3, &htim1, TIM_CHANNEL_4);
+  dshot_.init(AM32, DSHOT300, &htim1, TIM_CHANNEL_1, &htim1, TIM_CHANNEL_2, &htim1, TIM_CHANNEL_3, &htim1, TIM_CHANNEL_4);
   dshot_.initTelemetry(&huart2);
 
   controller_.init(&htim1, &htim4, &estimator_, &servo_, &dshot_, &battery_status_, &nh_, &flightControlMutexHandle);

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/dshot_esc/dshot.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/dshot_esc/dshot.cpp
@@ -5,7 +5,7 @@
 
 #include "dshot.h"
 
-void DShot::init(dshot_type_e dshot_type, TIM_HandleTypeDef* htim_motor_1, uint32_t channel_motor_1,
+void DShot::init(esc_type_e esc_type, dshot_type_e dshot_type, TIM_HandleTypeDef* htim_motor_1, uint32_t channel_motor_1,
                  TIM_HandleTypeDef* htim_motor_2, uint32_t channel_motor_2, TIM_HandleTypeDef* htim_motor_3,
                  uint32_t channel_motor_3, TIM_HandleTypeDef* htim_motor_4, uint32_t channel_motor_4)
 {
@@ -17,6 +17,21 @@ void DShot::init(dshot_type_e dshot_type, TIM_HandleTypeDef* htim_motor_1, uint3
   channel_motor_3_ = channel_motor_3;
   htim_motor_4_ = htim_motor_4;
   channel_motor_4_ = channel_motor_4;
+
+  switch (esc_type) {
+      case BEHELI:
+          if_init_esc_ = false;
+          init_duration_ = 0;
+          break;
+      case AM32:
+          if_init_esc_ = true;
+          init_duration_ = 5000; 
+          break;
+      default:
+          if_init_esc_ = false;
+          init_duration_ = 0;
+          break;
+  }
 
   dshot_set_timer(dshot_type);
   dshot_put_tc_callback_function();

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/dshot_esc/dshot.h
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/dshot_esc/dshot.h
@@ -64,13 +64,19 @@ typedef enum
   DSHOT600
 } dshot_type_e;
 
+typedef enum
+{
+  BEHELI,
+  AM32
+} esc_type_e;
+
 class DShot
 {
 public:
   DShot(){};
   ~DShot(){};
 
-  void init(dshot_type_e dshot_type, TIM_HandleTypeDef* htim_motor_1, uint32_t channel_motor_1,
+  void init(esc_type_e esc_type, dshot_type_e dshot_type, TIM_HandleTypeDef* htim_motor_1, uint32_t channel_motor_1,
             TIM_HandleTypeDef* htim_motor_2, uint32_t channel_motor_2, TIM_HandleTypeDef* htim_motor_3,
             uint32_t channel_motor_3, TIM_HandleTypeDef* htim_motor_4, uint32_t channel_motor_4);
   void initTelemetry(UART_HandleTypeDef* huart);
@@ -81,6 +87,10 @@ public:
   bool is_telemetry_ = false;
   int id_telem_ = 0;
   int id_telem_prev_ = -1;
+  // esc init
+  bool if_init_esc_ = false;
+  int init_count_  = 0;
+  int init_duration_ = 0; //hardcoding(tested): min init time 
 
   ESCReader esc_reader_;
 

--- a/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.cpp
+++ b/aerial_robot_nerve/spinal/mcu_project/lib/Jsk_Lib/flight_control/attitude/attitude_control.cpp
@@ -216,9 +216,28 @@ void AttitudeController::pwmsControl(void)
     uint16_t motor_v = (uint16_t)((target_pwm_[i] - 0.5) / 0.5 * DSHOT_RANGE + DSHOT_MIN_THROTTLE);
 
     if (motor_v > DSHOT_MAX_THROTTLE)
+    {
       motor_v = DSHOT_MAX_THROTTLE;
+    }
     else if (motor_v < DSHOT_MIN_THROTTLE)
+    {
       motor_v = DSHOT_MIN_THROTTLE;
+    }
+    // ESC init
+    // if (dshot_->if_init_esc_ /*&& motor_v == 0*/)
+    if (dshot_->if_init_esc_ && motor_v == DSHOT_MIN_THROTTLE)
+    {
+
+      motor_v = 0;
+      dshot_->init_count_ ++;
+
+      if (dshot_->init_count_ > dshot_->init_duration_)
+      {
+        dshot_->if_init_esc_ = false; 
+        dshot_->init_count_ = 0;
+      }
+
+    }
     
     motor_value[i] = motor_v;
   }


### PR DESCRIPTION
### What is this

Support dshot on AM32 esc by adding init step in `attitude_controller::update`  and defining new member varible `esc_type_e`  in `Dshot` class.   


 ### Detail
In order to support to the different esc when using dshot, new member varible  `typedef enum
{
  BEHELI,
  AM32
} esc_type_e;` has been declared. Currently we can select the esc type by changing `DShot::init(esc_type_e esc_type, ...)` in main.c in the corresponding mcu project folder.

### Todo 
Right now, the init duration for AM32 esc is hardcoded as `init_count_` member varible of `Dshot` class for disarming am32 esc thourgh tests. 
In the future, this duration could be replaced by receiving flag from esc. 