### PR TITLE
Refine roll and pitch traj for one more round; Deal with singular poses when two rotors are flipped back

### DIFF
--- a/robots/beetle_omni/config/BeetleNMPCFullDist.yaml
+++ b/robots/beetle_omni/config/BeetleNMPCFullDist.yaml
@@ -21,8 +21,8 @@ controller:
     thrust_max: 30  # N
     thrust_min: 0  # N
 
-    a_max: 3.92699  # 180 + 45 degree ~ 0.5
-    a_min: -3.92699
+    a_max: 3.15  # 180 deg + a little bit
+    a_min: -3.15
 
     # params for the cost function
     Qp_xy: 300

--- a/robots/beetle_omni/config/BeetleNMPCFullServoImp.yaml
+++ b/robots/beetle_omni/config/BeetleNMPCFullServoImp.yaml
@@ -17,8 +17,8 @@ controller:
     thrust_max: 30  # N
     thrust_min: 0  # N
 
-    a_max: 3.92699  # 180 + 45 degree ~ 0.5
-    a_min: -3.92699
+    a_max: 3.15  # 180 deg + a little bit
+    a_min: -3.15
 
     # params for the cost function
     enlarge_factor: 8

--- a/robots/beetle_omni/config/BeetleNMPCFullServoThrustDist.yaml
+++ b/robots/beetle_omni/config/BeetleNMPCFullServoThrustDist.yaml
@@ -17,8 +17,8 @@ controller:
     thrust_max: 30  # N
     thrust_min: 0  # N
 
-    a_max: 3.92699  # 180 + 45 degree ~ 0.5
-    a_min: -3.92699
+    a_max: 3.15  # 180 deg + a little bit
+    a_min: -3.15
 
     # params for the cost function
     Qp_xy: 300

--- a/robots/beetle_omni/config/BeetleNMPCFullServoThrustImp.yaml
+++ b/robots/beetle_omni/config/BeetleNMPCFullServoThrustImp.yaml
@@ -17,8 +17,8 @@ controller:
     thrust_max: 30  # N
     thrust_min: 0  # N
 
-    a_max: 3.92699  # 180 + 45 degree ~ 0.5
-    a_min: -3.92699
+    a_max: 3.15  # 180 deg + a little bit
+    a_min: -3.15
 
     # params for the cost function
     epsilon: 0.00001  # avoid the dividend is 0 when M = 0

--- a/robots/beetle_omni/scripts/analyze_allocation.py
+++ b/robots/beetle_omni/scripts/analyze_allocation.py
@@ -343,7 +343,15 @@ if __name__ == "__main__":
                 rotor_idx = np.intersect1d(rotor_idx_ft_cond[0], rotor_idx_alpha_cond[0])
 
                 if len(rotor_idx) > 1:
-                    raise RuntimeError("More than one rotor is below threshold and flip backwards!")
+                    max_ft = 0.0
+                    max_rotor_idx = -1
+                    for i in rotor_idx:
+                        if ft_ref[i] > max_ft:
+                            max_ft = ft_ref[i]
+                            max_rotor_idx = i
+
+                    rotor_idx = max_rotor_idx
+                    print(f"Multiple rotors below threshold, using rotor {rotor_idx + 1} with thrust {max_ft:.2f} N")
                 elif len(rotor_idx) == 0:
                     rotor_idx = -1
                 elif len(rotor_idx) == 1:


### PR DESCRIPTION
### What is this

1. Refine roll and pitch traj for one more round for better visualization.

2. In some cases, the robot may face the problem that two rotors are flipped back. Previously, I just raise the error. Now, the rotor with larger thrust will be chosen. This is not perfect when the tilting surface is over 93 deg, but is OK for 90 deg. This part needs more exploration in the future.