### PR TITLE
[Enhancement] Refine takeoff

### DIFF
--- a/aerial_robot_control/include/aerial_robot_control/nmpc/base_mpc_solver.h
+++ b/aerial_robot_control/include/aerial_robot_control/nmpc/base_mpc_solver.h
@@ -73,12 +73,16 @@ public:
     setRTIPhase();
   };
 
-  void reset(const std::vector<std::vector<double>>& x_init, const std::vector<std::vector<double>>& u_init)
+  /* Note: extract resetXrUr out of resetSolver since the xr & ur might be different from x & u in the solver.
+   * For example, for EE-centric NMPC, the xr & ur are in the EE frame but x & u are in the CoG frame. */
+  void resetXrUr(const std::vector<std::vector<double>>& xr_init, const std::vector<std::vector<double>>& ur_init)
   {
-    // reset ref
-    xr_ = x_init;
-    ur_ = u_init;
+    xr_ = xr_init;
+    ur_ = ur_init;
+  }
 
+  void resetSolver(const std::vector<std::vector<double>>& x_init, const std::vector<std::vector<double>>& u_init)
+  {
     // reset solver
     if (x_init.size() != NN_ + 1 || u_init.size() != NN_)
       throw std::length_error("x_init or u_init size is not equal to NN_ + 1 or NN_");
@@ -98,14 +102,25 @@ public:
     getSolution();
   }
 
-  void resetByX0U0(const std::vector<double>& x0, const std::vector<double>& u0)
+  void resetXrUrByX0U0(const std::vector<double>& x0, const std::vector<double>& u0)
   {
     if (x0.size() != NX_ || u0.size() != NU_)
       throw std::length_error("x0 or u0 size is not equal to NX_ or NU_");
 
-    std::vector<std::vector<double>> x_init(NN_ + 1, x0);
-    std::vector<std::vector<double>> u_init(NN_, u0);
-    reset(x_init, u_init);
+    std::vector xr_init(NN_ + 1, x0);
+    std::vector ur_init(NN_, u0);
+
+    resetXrUr(xr_init, ur_init);
+  }
+
+  void resetSolverByX0U0(const std::vector<double>& x0, const std::vector<double>& u0)
+  {
+    if (x0.size() != NX_ || u0.size() != NU_)
+      throw std::length_error("x0 or u0 size is not equal to NX_ or NU_");
+
+    std::vector x_init(NN_ + 1, x0);
+    std::vector u_init(NN_, u0);
+    resetSolver(x_init, u_init);
   }
 
   int solve(const std::vector<double>& bx0, const bool is_debug = false)

--- a/aerial_robot_control/include/aerial_robot_control/nmpc/tilt_mt_servo_dist_nmpc_controller.h
+++ b/aerial_robot_control/include/aerial_robot_control/nmpc/tilt_mt_servo_dist_nmpc_controller.h
@@ -60,7 +60,7 @@ protected:
 
   void prepareNMPCParams() override;
 
-  std::vector<double> meas2VecX() override;
+  std::vector<double> meas2VecX(bool is_ee_centric) override;
 
   void initAllocMat() override;
 

--- a/aerial_robot_control/include/aerial_robot_control/nmpc/tilt_mt_servo_nmpc_controller.h
+++ b/aerial_robot_control/include/aerial_robot_control/nmpc/tilt_mt_servo_nmpc_controller.h
@@ -167,7 +167,12 @@ protected:
   double getCommand(int idx_u, double T_horizon = 0.0) const;
 
   // conversion functions
-  std::vector<double> meas2VecX() override;
+  std::vector<double> meas2VecX() override
+  {
+    return meas2VecX(false);
+  }
+
+  virtual std::vector<double> meas2VecX(bool is_ee_centric);
 
   // ensure the continuity of servo angles
   double ensureOneServoContinuity(double a_ref, int idx) const;

--- a/aerial_robot_control/include/aerial_robot_control/nmpc/tilt_mt_servo_nmpc_controller.h
+++ b/aerial_robot_control/include/aerial_robot_control/nmpc/tilt_mt_servo_nmpc_controller.h
@@ -120,6 +120,10 @@ protected:
   bool is_set_fix_rotor_ = false;
   aerial_robot_msgs::FixRotor fix_rotor_msg_;
 
+  // For different vel during takeoff and landing
+  bool has_restored_vel_ = false;  // whether the velocity is restored to set value when hovering
+  double vel_max_, vel_min_, vel_limit_takeoff_;
+
   /* initialize() */
   virtual void initPlugins() {};
   virtual void initGeneralParams();
@@ -136,6 +140,8 @@ protected:
   virtual void initNMPCParams();
   void updateInertialParams();
   std::vector<double> PhysToNMPCParams() const;
+
+  void modifyVelConstraints(double vel_min, double vel_max) const;
 
   /* update() */
   void controlCore() override;

--- a/aerial_robot_control/include/aerial_robot_control/nmpc/tilt_mt_servo_nmpc_controller.h
+++ b/aerial_robot_control/include/aerial_robot_control/nmpc/tilt_mt_servo_nmpc_controller.h
@@ -164,7 +164,7 @@ protected:
 
   /* utils */
   // get functions
-  double getCommand(int idx_u, double T_horizon = 0.0);
+  double getCommand(int idx_u, double T_horizon = 0.0) const;
 
   // conversion functions
   std::vector<double> meas2VecX() override;
@@ -177,7 +177,7 @@ protected:
   void printPhysicalParams();
 
   // check functions
-  inline bool isAlmostEqual(const double a, const double b, const double epsilon = 1e-6)
+  static bool isAlmostEqual(const double a, const double b, const double epsilon = 1e-6)
   {
     return std::fabs(a - b) < epsilon;
   }

--- a/aerial_robot_control/include/aerial_robot_control/nmpc/tilt_mt_servo_thrust_dist_nmpc_controller.h
+++ b/aerial_robot_control/include/aerial_robot_control/nmpc/tilt_mt_servo_thrust_dist_nmpc_controller.h
@@ -43,7 +43,7 @@ protected:
 
   void callbackESCTelem(const spinal::ESCTelemetryArrayConstPtr& msg);
 
-  std::vector<double> meas2VecX() override;
+  std::vector<double> meas2VecX(bool is_ee_centric) override;
 
   void allocateToXU(const tf::Vector3& ref_pos_i, const tf::Vector3& ref_vel_i, const tf::Quaternion& ref_quat_ib,
                     const tf::Vector3& ref_omega_b, const VectorXd& ref_wrench_b, vector<double>& x,

--- a/aerial_robot_control/src/nmpc/tilt_mt_servo_dist_nmpc_controller.cpp
+++ b/aerial_robot_control/src/nmpc/tilt_mt_servo_dist_nmpc_controller.cpp
@@ -125,7 +125,7 @@ void nmpc::TiltMtServoDistNMPC::prepareNMPCParams()
   mpc_solver_ptr_->setParamSparseAllStages(idx, p);
 }
 
-std::vector<double> nmpc::TiltMtServoDistNMPC::meas2VecX()
+std::vector<double> nmpc::TiltMtServoDistNMPC::meas2VecX(bool is_ee_centric)
 {
   /* disturbance rejection */
   geometry_msgs::Vector3 external_force_w;     // default: 0, 0, 0
@@ -144,7 +144,7 @@ std::vector<double> nmpc::TiltMtServoDistNMPC::meas2VecX()
     updateWrenchImpactCoeff(external_force_w, external_torque_cog);
   }
 
-  vector<double> bx0 = TiltMtServoNMPC::meas2VecX();
+  vector<double> bx0 = TiltMtServoNMPC::meas2VecX(is_ee_centric);
 
   bx0[13 + joint_num_ + 0] = external_force_w.x * impact_coeff_force_;
   bx0[13 + joint_num_ + 1] = external_force_w.y * impact_coeff_force_;

--- a/aerial_robot_control/src/nmpc/tilt_mt_servo_nmpc_controller.cpp
+++ b/aerial_robot_control/src/nmpc/tilt_mt_servo_nmpc_controller.cpp
@@ -225,8 +225,8 @@ void nmpc::TiltMtServoNMPC::initNMPCConstraints()
   getParam<double>(nmpc_nh, "a_max", servo_angle_max_, 3.1416);
   getParam<double>(nmpc_nh, "a_min", servo_angle_min_, -3.1416);
 
-  //  TODO: this should be set in flight_navigation
-  getParam<double>(control_nh, "vel_limit_takeoff", vel_limit_takeoff_, 0.5);
+  //  TODO: this should be set in flight_navigation; don't know why set 0.2 results solver failure
+  getParam<double>(control_nh, "vel_limit_takeoff", vel_limit_takeoff_, 1.0);  // m/s
 
   // lbx and ubx
   std::vector<int> idxbx = mpc_solver_ptr_->getConstraintsIdxbx();

--- a/aerial_robot_control/src/nmpc/tilt_mt_servo_nmpc_controller.cpp
+++ b/aerial_robot_control/src/nmpc/tilt_mt_servo_nmpc_controller.cpp
@@ -1065,7 +1065,7 @@ void nmpc::TiltMtServoNMPC::cfgNMPCCallback(NMPCConfig& config, uint32_t level)
   }
 }
 
-double nmpc::TiltMtServoNMPC::getCommand(int idx_u, double T_horizon)
+double nmpc::TiltMtServoNMPC::getCommand(int idx_u, double T_horizon) const
 {
   if (T_horizon == 0)
     return mpc_solver_ptr_->uo_.at(0).at(idx_u);

--- a/aerial_robot_control/src/nmpc/tilt_mt_servo_thrust_dist_nmpc_controller.cpp
+++ b/aerial_robot_control/src/nmpc/tilt_mt_servo_thrust_dist_nmpc_controller.cpp
@@ -208,7 +208,7 @@ void nmpc::TiltMtServoThrustDistNMPC::allocateToXU(const tf::Vector3& ref_pos_i,
   }
 }
 
-std::vector<double> nmpc::TiltMtServoThrustDistNMPC::meas2VecX()
+std::vector<double> nmpc::TiltMtServoThrustDistNMPC::meas2VecX(bool is_ee_centric)
 {
   /* disturbance rejection */
   geometry_msgs::Vector3 external_force_w;     // default: 0, 0, 0
@@ -225,7 +225,7 @@ std::vector<double> nmpc::TiltMtServoThrustDistNMPC::meas2VecX()
     external_torque_cog = wrench_est_ptr_->getDistTorqueCOG();
   }
 
-  auto bx0 = TiltMtServoNMPC::meas2VecX();
+  auto bx0 = TiltMtServoNMPC::meas2VecX(is_ee_centric);
 
   for (int i = 0; i < motor_num_; i++)
     bx0[13 + joint_num_ + i] = thrust_meas_[i];


### PR DESCRIPTION
### What is this

Enhance two aspects in takeoff:

1. set the initial reference to EE-centric if it is.
2. change the vel constraints during takeoff, making it slower and seems to be safer in real flight.

The current vel limit in takeoff is named "vel_limit_takeoff", and the default value is 0.5 m/s.