### PR TITLE
Clean up the code and fix some bugs in simulation or visualization

### DIFF
--- a/aerial_robot_base/src/aerial_robot_base.cpp
+++ b/aerial_robot_base/src/aerial_robot_base.cpp
@@ -1,13 +1,15 @@
 #include <aerial_robot_base/aerial_robot_base.h>
 
 AerialRobotBase::AerialRobotBase(ros::NodeHandle nh, ros::NodeHandle nh_private)
-  : nh_(nh), nhp_(nh_private), callback_spinner_(4), main_loop_spinner_(1, &main_loop_queue_),
-    controller_loader_("aerial_robot_control", "aerial_robot_control::ControlBase"),
-    navigator_loader_("aerial_robot_control", "aerial_robot_navigation::BaseNavigator")
+  : nh_(nh)
+  , nhp_(nh_private)
+  , callback_spinner_(4)
+  , main_loop_spinner_(1, &main_loop_queue_)
+  , controller_loader_("aerial_robot_control", "aerial_robot_control::ControlBase")
+  , navigator_loader_("aerial_robot_control", "aerial_robot_navigation::BaseNavigator")
 {
-
-  nhp_.param ("param_verbose", param_verbose_, true);
-  nhp_.param ("main_rate", main_rate_, 0.0);
+  nhp_.param("param_verbose", param_verbose_, true);
+  nhp_.param("main_rate", main_rate_, 0.0);
 
   // robot model
   robot_model_ros_ = boost::make_shared<aerial_robot_model::RobotModelRos>(nh_, nhp_);
@@ -19,82 +21,71 @@ AerialRobotBase::AerialRobotBase(ros::NodeHandle nh, ros::NodeHandle nh_private)
 
   // navigation
   std::string navi_plugin_name;
-  if(nh_.getParam("flight_navigation_plugin_name", navi_plugin_name))
+  if (nh_.getParam("flight_navigation_plugin_name", navi_plugin_name))
+  {
+    try
     {
-      try
-        {
-          navigator_ = navigator_loader_.createInstance(navi_plugin_name);
-        }
-      catch(pluginlib::PluginlibException& ex)
-        {
-          ROS_ERROR("The plugin failed to load for some reason. Error: %s", ex.what());
-        }
+      navigator_ = navigator_loader_.createInstance(navi_plugin_name);
     }
+    catch (pluginlib::PluginlibException& ex)
+    {
+      ROS_ERROR("The plugin failed to load for some reason. Error: %s", ex.what());
+    }
+  }
   else
-    {
-      ROS_DEBUG("use default class for flight navigation: aerial_robot_navigation::BaseNavigator");
-      navigator_ = boost::make_shared<aerial_robot_navigation::BaseNavigator>();
-    }
+  {
+    ROS_DEBUG("use default class for flight navigation: aerial_robot_navigation::BaseNavigator");
+    navigator_ = boost::make_shared<aerial_robot_navigation::BaseNavigator>();
+  }
   navigator_->initialize(nh_, nhp_, robot_model, estimator_);
 
   //  controller
   try
-    {
-      std::string aerial_robot_control_name;
-      nh_.param ("aerial_robot_control_name", aerial_robot_control_name, std::string("aerial_robot_control/flatness_pid"));
-      controller_ = controller_loader_.createInstance(aerial_robot_control_name);
-      controller_->initialize(nh_, nhp_, robot_model, estimator_, navigator_, main_rate_);
-    }
-  catch(pluginlib::PluginlibException& ex)
-    {
-      ROS_ERROR("The plugin failed to load for some reason. Error: %s", ex.what());
-    }
+  {
+    std::string aerial_robot_control_name;
+    nh_.param("aerial_robot_control_name", aerial_robot_control_name, std::string("aerial_robot_control/flatness_pid"));
+    controller_ = controller_loader_.createInstance(aerial_robot_control_name);
+    controller_->initialize(nh_, nhp_, robot_model, estimator_, navigator_, main_rate_);
+  }
+  catch (pluginlib::PluginlibException& ex)
+  {
+    ROS_ERROR("The plugin failed to load for some reason. Error: %s", ex.what());
+  }
 
-  if(param_verbose_) cout << nhp_.getNamespace() << ": main_rate is " << main_rate_ << endl;
-  if(main_rate_ <= 0)
+  if (param_verbose_)
+    cout << nhp_.getNamespace() << ": main_rate is " << main_rate_ << endl;
+  if (main_rate_ <= 0)
     ROS_ERROR_STREAM("mian rate is negative, can not run the main timer");
   else
-    {
-      // note1: separate the thread for main control (including navigation) loop to guarantee a relatively stable loop rate
+  {
+    // note1: separate the thread for main control (including navigation) loop to guarantee a relatively stable loop
+    // rate
 
-      ros::TimerOptions ops(ros::Duration(1.0 / main_rate_),
-                            boost::bind(&AerialRobotBase::mainFunc, this, _1),
-                            &main_loop_queue_);
-      main_timer_ = nhp_.createTimer(ops);
-      main_loop_spinner_.start();
-    }
-
+    ros::TimerOptions ops(ros::Duration(1.0 / main_rate_), boost::bind(&AerialRobotBase::mainFunc, this, _1),
+                          &main_loop_queue_);
+    main_timer_ = nhp_.createTimer(ops);
+    main_loop_spinner_.start();
+  }
 
   // note2: callback_spinner_ calls following items with 4 threads
   //  - all subscribers (joint state for robot model, sensor for state estimation, uav/nav for navigation)
   //  - statePublish timer in state estimator for publish odometry and tf
   //  - service server
   callback_spinner_.start();
-
 }
 
 AerialRobotBase::~AerialRobotBase()
 {
   // stop manually to avoid following error (message)
-  // terminate called after throwing an instance of 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::lock_error> >'
-  // what():  boost: mutex lock failed in pthread_mutex_lock: Invalid argument
+  // terminate called after throwing an instance of
+  // 'boost::exception_detail::clone_impl<boost::exception_detail::error_info_injector<boost::lock_error> >' what():
+  // boost: mutex lock failed in pthread_mutex_lock: Invalid argument
   main_timer_.stop();
   main_loop_spinner_.stop();
 }
 
-void AerialRobotBase::mainFunc(const ros::TimerEvent & e)
+void AerialRobotBase::mainFunc(const ros::TimerEvent& e)
 {
-  if (!e.last_real.isZero())
-  {
-      double dt_real = e.current_real.toSec() - e.last_real.toSec();
-      double tolerance = 0.05;  // 5% tolerance. This value is set based on experience.
-      double dt_desire = (1.0 + tolerance) * 1.0 / main_rate_;
-      if (dt_real > dt_desire)
-      {
-          ROS_WARN("main loop rate is too low: (ts_real) %f s > (ts_desire with %2f%% tolerance) %f s ", dt_real,
-                   tolerance * 100, dt_desire);
-      }
-  }
   navigator_->update();
   controller_->update();
 }

--- a/aerial_robot_control/include/aerial_robot_control/nmpc/base_mpc_controller.h
+++ b/aerial_robot_control/include/aerial_robot_control/nmpc/base_mpc_controller.h
@@ -21,17 +21,13 @@ namespace nmpc
 class BaseMPC : public ControlBase
 {
 public:
-protected:
-  // define MPC solver
-  boost::shared_ptr<pluginlib::ClassLoader<aerial_robot_control::mpc_solver::BaseMPCSolver>> mpc_solver_loader_ptr_;
-  boost::shared_ptr<aerial_robot_control::mpc_solver::BaseMPCSolver> mpc_solver_ptr_;
+  BaseMPC() = default;
+  ~BaseMPC() override = default;
 
-  /* initialize() */
-  inline void initialize(ros::NodeHandle nh, ros::NodeHandle nhp,
-                         boost::shared_ptr<aerial_robot_model::RobotModel> robot_model,
-                         boost::shared_ptr<aerial_robot_estimation::StateEstimator> estimator,
-                         boost::shared_ptr<aerial_robot_navigation::BaseNavigator> navigator,
-                         double ctrl_loop_du) override
+  void initialize(ros::NodeHandle nh, ros::NodeHandle nhp,
+                  boost::shared_ptr<aerial_robot_model::RobotModel> robot_model,
+                  boost::shared_ptr<aerial_robot_estimation::StateEstimator> estimator,
+                  boost::shared_ptr<aerial_robot_navigation::BaseNavigator> navigator, double ctrl_loop_du) override
   {
     ControlBase::initialize(nh, nhp, robot_model, estimator, navigator, ctrl_loop_du);
 
@@ -61,8 +57,71 @@ protected:
     {
       ROS_ERROR("mpc_solver_plugin: The plugin failed to load for some reason. Error: %s", ex.what());
     }
+
+    /* init plugins */
+    initPlugins();
+
+    /* init general parameters */
+    initGeneralParams();
+
+    /* init cost weight parameters */
+    initNMPCCostW();
+
+    /* init constraints */
+    initNMPCConstraints();
   }
 
+  void activate() override
+  {
+    initNMPCParams();
+    ControlBase::activate();
+  }
+
+  bool update() override
+  {
+    ros::Time now = ros::Time::now();
+
+    // init t_last_
+    if (t_last_.is_zero())
+    {
+      t_last_ = now;
+      return ControlBase::update();
+    }
+
+    const double dt = (now - t_last_).toSec();
+
+    // init dt_last_
+    if (dt_last_ == 0.0)
+    {
+      dt_last_ = dt;
+      return ControlBase::update();
+    }
+
+    // check the update rate
+    const double dt_average = (dt_last_ + dt) / 2.0;
+    const double tol = 0.11;
+    if (dt_average > 1 / ctrl_loop_du_ * (1 + tol) || dt_average < 1 / ctrl_loop_du_ * (1 - tol))
+    {
+      ROS_WARN("NMPC controller update rate is not stable (2 average): %.4f, expected: %.4f, tolerance: %.2f %%",
+               dt_average, 1 / ctrl_loop_du_, tol * 100);
+    }
+
+    dt_last_ = dt;
+    t_last_ = now;
+
+    return ControlBase::update();
+  }
+
+protected:
+  // define MPC solver
+  boost::shared_ptr<pluginlib::ClassLoader<aerial_robot_control::mpc_solver::BaseMPCSolver>> mpc_solver_loader_ptr_;
+  boost::shared_ptr<aerial_robot_control::mpc_solver::BaseMPCSolver> mpc_solver_ptr_;
+
+  /* initialize() */
+  virtual void initPlugins() {};
+  virtual void initGeneralParams() = 0;
+  virtual void initNMPCCostW() = 0;
+  virtual void initNMPCConstraints() = 0;
   // define the ROS msg related to MPC
   inline static void initPredXU(aerial_robot_msgs::PredXU& x_u, int nn, int nx, int nu)
   {
@@ -94,8 +153,14 @@ protected:
     std::fill(x_u.u.data.begin(), x_u.u.data.end(), 0.0);
   }
 
+  /* activate() */
+  virtual void initNMPCParams() = 0;
+
   /* update() */
   // 1. set reference for NMPC
+  virtual void prepareNMPCRef() = 0;
+  virtual void prepareNMPCParams() {};
+
   virtual void callbackSetRefXU(const aerial_robot_msgs::PredXUConstPtr& msg) = 0;
   static void rosXU2VecXU(const aerial_robot_msgs::PredXU& x_u, std::vector<std::vector<double>>& x_vec,
                           std::vector<std::vector<double>>& u_vec)
@@ -126,6 +191,10 @@ protected:
   virtual void sendCmd() = 0;
   // 5. viz the result in RVIZ
   virtual void callbackViz(const ros::TimerEvent& event) = 0;
+
+private:
+  double dt_last_;
+  ros::Time t_last_;
 };
 
 }  // namespace nmpc

--- a/aerial_robot_control/include/aerial_robot_control/nmpc/tilt_mt_servo_nmpc_controller.h
+++ b/aerial_robot_control/include/aerial_robot_control/nmpc/tilt_mt_servo_nmpc_controller.h
@@ -123,10 +123,10 @@ protected:
   double vel_max_, vel_min_, vel_limit_takeoff_;
 
   /* initialize() */
-  virtual void initPlugins() {};
-  virtual void initGeneralParams();
-  virtual void initNMPCCostW();
-  virtual void initNMPCConstraints();
+  void initGeneralParams() override;
+  void initNMPCCostW() override;
+  void initNMPCConstraints() override;
+
   void setControlMode();
   virtual inline void initActuatorStates()
   {
@@ -137,11 +137,11 @@ protected:
   virtual void resetPlugins() {};
 
   /* activate() */
+  void initNMPCParams() override;
+
   virtual void initAllocMat();
-  virtual void initNMPCParams();
   void updateInertialParams();
   std::vector<double> PhysToNMPCParams() const;
-
   void modifyVelConstraints(double vel_min, double vel_max) const;
 
   /* update() */
@@ -149,8 +149,9 @@ protected:
   void sendCmd() override;
 
   // controlCore()
-  void prepareNMPCRef();
-  virtual void prepareNMPCParams();
+  void prepareNMPCRef() override;
+  void prepareNMPCParams() override;
+
   void setXrUrRef(const tf::Vector3& ref_pos_i, const tf::Vector3& ref_vel_i, const tf::Vector3& ref_acc_i,
                   const tf::Quaternion& ref_quat_ib, const tf::Vector3& ref_omega_b, const tf::Vector3& ref_ang_acc_b,
                   const int& horizon_idx);

--- a/aerial_robot_control/include/aerial_robot_control/nmpc/tilt_mt_servo_nmpc_controller.h
+++ b/aerial_robot_control/include/aerial_robot_control/nmpc/tilt_mt_servo_nmpc_controller.h
@@ -24,7 +24,6 @@
 #include "aerial_robot_msgs/FixRotor.h"
 #include "spinal/FourAxisCommand.h"
 #include "spinal/SetControlMode.h"
-#include "spinal/FlightConfigCmd.h"
 #include "spinal/DesireCoord.h"
 
 /* action */
@@ -59,11 +58,10 @@ public:
 protected:
   ros::Timer tmr_viz_;
 
-  ros::Publisher pub_viz_pred_;                  // for viz predictions
-  ros::Publisher pub_viz_ref_;                   // for viz reference
-  ros::Publisher pub_flight_cmd_;                // for spinal
-  ros::Publisher pub_gimbal_control_;            // for gimbal control
-  ros::Publisher pub_flight_config_cmd_spinal_;  // for spinal, enable the gyro measurement after the takeoff
+  ros::Publisher pub_viz_pred_;        // for viz predictions
+  ros::Publisher pub_viz_ref_;         // for viz reference
+  ros::Publisher pub_flight_cmd_;      // for spinal
+  ros::Publisher pub_gimbal_control_;  // for gimbal control
 
   ros::ServiceClient srv_set_control_mode_;
   std::vector<boost::shared_ptr<NMPCControlDynamicConfig>> nmpc_reconf_servers_;

--- a/aerial_robot_control/src/nmpc/tilt_mt_servo_nmpc_controller.cpp
+++ b/aerial_robot_control/src/nmpc/tilt_mt_servo_nmpc_controller.cpp
@@ -142,6 +142,11 @@ void nmpc::TiltMtServoNMPC::initGeneralParams()
   getParam<double>(nmpc_nh, "T_step", t_nmpc_step_, 0.1);
   getParam<double>(nmpc_nh, "T_horizon", t_nmpc_horizon_, 2.0);
 
+  if (t_nmpc_samp_ != 1 / ctrl_loop_du_)
+    throw std::runtime_error(
+        "The NMPC sampling time T_samp is not equal to the control loop time! Please set T_step to 1/ctrl_loop_du_ in "
+        "the config.");
+
   getParam<bool>(nmpc_nh, "is_attitude_ctrl", is_attitude_ctrl_, true);
   getParam<bool>(nmpc_nh, "is_body_rate_ctrl", is_body_rate_ctrl_, false);
   getParam<bool>(nmpc_nh, "is_print_phys_params", is_print_phys_params_, false);

--- a/aerial_robot_control/src/nmpc/tilt_mt_servo_nmpc_controller.cpp
+++ b/aerial_robot_control/src/nmpc/tilt_mt_servo_nmpc_controller.cpp
@@ -45,7 +45,6 @@ void nmpc::TiltMtServoNMPC::initialize(ros::NodeHandle nh, ros::NodeHandle nhp,
   pub_viz_ref_ = nh_.advertise<geometry_msgs::PoseArray>("nmpc/viz_ref", 1);
   pub_flight_cmd_ = nh_.advertise<spinal::FourAxisCommand>("four_axes/command", 1);
   pub_gimbal_control_ = nh_.advertise<sensor_msgs::JointState>("gimbals_ctrl", 1);
-  pub_flight_config_cmd_spinal_ = nh_.advertise<spinal::FlightConfigCmd>("flight_config_cmd", 1);
 
   /* services */
   srv_set_control_mode_ = nh_.serviceClient<spinal::SetControlMode>("set_control_mode");
@@ -84,11 +83,7 @@ void nmpc::TiltMtServoNMPC::activate()
   modifyVelConstraints(-vel_limit_takeoff_, vel_limit_takeoff_);
   has_restored_vel_ = false;  // reset the flag, so that we can restore the velocity after hovering
 
-  /* also for some commands that should be sent after takeoff */
-  // enable imu sending, only works in simulation. TODO: check its compatibility with real robot
-  spinal::FlightConfigCmd flight_config_cmd;
-  flight_config_cmd.cmd = spinal::FlightConfigCmd::INTEGRATION_CONTROL_ON_CMD;
-  pub_flight_config_cmd_spinal_.publish(flight_config_cmd);
+  BaseMPC::activate();
 }
 
 bool nmpc::TiltMtServoNMPC::update()

--- a/aerial_robot_control/src/nmpc/tilt_mt_servo_nmpc_controller.cpp
+++ b/aerial_robot_control/src/nmpc/tilt_mt_servo_nmpc_controller.cpp
@@ -14,18 +14,6 @@ void nmpc::TiltMtServoNMPC::initialize(ros::NodeHandle nh, ros::NodeHandle nhp,
 {
   BaseMPC::initialize(nh, nhp, robot_model, estimator, navigator, ctrl_loop_du);
 
-  /* init plugins */
-  initPlugins();
-
-  /* init general parameters */
-  initGeneralParams();
-
-  /* init cost weight parameters */
-  initNMPCCostW();
-
-  /* init constraints */
-  initNMPCConstraints();
-
   /* init dynamic reconfigure */
   ros::NodeHandle control_nh(nh_, "controller");
   ros::NodeHandle nmpc_nh(control_nh, "nmpc");
@@ -70,11 +58,8 @@ void nmpc::TiltMtServoNMPC::initialize(ros::NodeHandle nh, ros::NodeHandle nhp,
 
 void nmpc::TiltMtServoNMPC::activate()
 {
-  ControlBase::activate();
-
   initAllocMat();
   updateInertialParams();
-  initNMPCParams();
 
   if (is_print_phys_params_)
     printPhysicalParams();
@@ -88,7 +73,7 @@ void nmpc::TiltMtServoNMPC::activate()
 
 bool nmpc::TiltMtServoNMPC::update()
 {
-  if (!ControlBase::update())
+  if (!BaseMPC::update())
     return false;
 
   this->controlCore();
@@ -99,7 +84,7 @@ bool nmpc::TiltMtServoNMPC::update()
 
 void nmpc::TiltMtServoNMPC::reset()
 {
-  ControlBase::reset();
+  BaseMPC::reset();
 
   resetPlugins();
 

--- a/robots/gimbalrotor/launch/bringup_nmpc_full.launch
+++ b/robots/gimbalrotor/launch/bringup_nmpc_full.launch
@@ -66,7 +66,7 @@
   <node pkg="aerial_robot_base" type="aerial_robot_base_node" name="aerial_robot_base_node" ns="$(arg robot_ns)" output="screen" >
     <param name="tf_prefix" value="$(arg robot_ns)"/>
     <param name="param_verbose" value="false"/>
-    <param name="main_rate" value="40"/>
+    <param name="main_rate" value="100"/>
   </node>
 
   ###########  Robot Model  ###########


### PR DESCRIPTION
### What is this

Clean up the code and fix some bugs in simulation and visualization, especially the bug of checking the control loop time. Previously, there is always an issue as  "main loop rate is too low: (ts_real) 0.011000 s > (ts_desire with 5.000000% tolerance) 0.010500 s", but don't appear in real world.

The problem is, I use wall time to check the control time, but ROS timer is called based on the simulate time. According to GPT, the best way is in real world we use real time, but in simulation we use simulation time. I change the code to ros::time::now(), and use the average of two round as the criteria.

Also revise the bug for the viz of wrench est. ring.