### PR TITLE
Make the parameters in python files independent to ROS package

### DIFF
--- a/aerial_robot_control/scripts/nmpc/nmpc_tilt_mt/archive/phys_param_beetle_art.py
+++ b/aerial_robot_control/scripts/nmpc/nmpc_tilt_mt/archive/phys_param_beetle_art.py
@@ -1,46 +1,30 @@
-import os
-import yaml
-import rospkg
+# 2025-10-08 copy parameters from PhysParamBeetleArt.yaml to be independent of beetle package
+# these parameters are used in GitHub action to ensure the correctness of the nmpc code
+# In real usage, these parameters will be reloaded from URDF.
 
-# Read parameters from configuration file in the robot's package
-rospack = rospkg.RosPack()
+mass = 2.773
+gravity = 9.798
+Ixx = 0.04170
+Iyy = 0.03945
+Izz = 0.07068
+dr1 = 1
+p1_b = [0.137712, 0.137882, 0.0297217]
+dr2 = -1
+p2_b = [-0.137745, 0.137882, 0.0297217]
+dr3 = 1
+p3_b = [-0.137745, -0.138284, 0.0297217]
+dr4 = -1
+p4_b = [0.137712, -0.138284, 0.0297217]
+kq_d_kt = 0.0153
 
-try:
-    physical_param_path = os.path.join(rospack.get_path("beetle"), "config", "PhysParamBeetleArt.yaml")
-except rospkg.common.ResourceNotFound:  # non-ROS environment
-    # Fallback: construct absolute path from current file
-    this_dir = os.path.dirname(os.path.abspath(__file__))
-    project_root = os.path.abspath(os.path.join(this_dir, "../../../../.."))
-    physical_param_path = os.path.join(project_root, "robots/beetle/config/PhysParamBeetleArt.yaml")
+t_servo = 0.085883  # Time constant of servo
+t_rotor = 0.0942  # Time constant of rotor
 
-
-with open(physical_param_path, "r") as f:
-    physical_param_dict = yaml.load(f, Loader=yaml.FullLoader)
-physical_params = physical_param_dict["physical"]
-
-mass = physical_params["mass"]
-gravity = physical_params["gravity"]
-Ixx = physical_params["inertia_diag"][0]
-Iyy = physical_params["inertia_diag"][1]
-Izz = physical_params["inertia_diag"][2]
-dr1 = physical_params["dr1"]
-p1_b = physical_params["p1"]
-dr2 = physical_params["dr2"]
-p2_b = physical_params["p2"]
-dr3 = physical_params["dr3"]
-p3_b = physical_params["p3"]
-dr4 = physical_params["dr4"]
-p4_b = physical_params["p4"]
-kq_d_kt = physical_params["kq_d_kt"]
-
-t_servo = physical_params["t_servo"]  # Time constant of servo
-t_rotor = physical_params["t_rotor"]  # Time constant of rotor
-
-c0 = physical_params["c0"]
-c1 = physical_params["c1"]
-c2 = physical_params["c2"]
-c3 = physical_params["c3"]
-c4 = physical_params["c4"]
+c0 = -0.00278
+c1 = -0.02147
+c2 = 0.08134
+c3 = 0.00470
+c4 = -0.02439
 
 # fmt: off
 # concatenate the parameters to make a new list

--- a/aerial_robot_control/scripts/nmpc/nmpc_tilt_mt/fix_qd/phys_param_mini_qd.py
+++ b/aerial_robot_control/scripts/nmpc/nmpc_tilt_mt/fix_qd/phys_param_mini_qd.py
@@ -1,36 +1,21 @@
-import yaml
-import os
-import rospkg
+# 2025-10-08 copy parameters to be independent of any ROS package
+# these parameters are used in GitHub action to ensure the correctness of the nmpc code
+# In real usage, these parameters will be reloaded from URDF.
 
-# read parameters from yaml
-rospack = rospkg.RosPack()
-
-try:
-    physical_param_path = os.path.join(rospack.get_path("mini_quadrotor"), "config", "FlightControlNMPCFullModel.yaml")
-except rospkg.common.ResourceNotFound:
-    # Fallback: construct absolute path from current file
-    this_dir = os.path.dirname(os.path.abspath(__file__))
-    project_root = os.path.abspath(os.path.join(this_dir, "../../../../.."))
-    physical_param_path = os.path.join(project_root, "robots/mini_quadrotor/config/FlightControlNMPCFullModel.yaml")
-
-with open(physical_param_path, "r") as f:
-    physical_param_dict = yaml.load(f, Loader=yaml.FullLoader)
-physical_params = physical_param_dict["physical"]
-
-mass = physical_params["mass"]
-gravity = physical_params["gravity"]
-Ixx = physical_params["inertia_diag"][0]
-Iyy = physical_params["inertia_diag"][1]
-Izz = physical_params["inertia_diag"][2]
-dr1 = physical_params["dr1"]
-dr2 = physical_params["dr2"]
-dr3 = physical_params["dr3"]
-dr4 = physical_params["dr4"]
-p1_b = physical_params["p1"]
-p2_b = physical_params["p2"]
-p3_b = physical_params["p3"]
-p4_b = physical_params["p4"]
-kq_d_kt = physical_params["kq_d_kt"]
+mass = 1.0564  # kg
+gravity = 9.798  # m/s^2
+Ixx = 0.00867032  # kg m^2
+Iyy = 0.00867103
+Izz = 0.00979117
+dr1 = -1
+dr2 = 1
+dr3 = -1
+dr4 = 1
+p1_b = [-0.0865752, -0.085, 0.0108557]
+p2_b = [0.0834248, -0.085, 0.0108557]
+p3_b = [0.0834248, 0.085, 0.0108557]
+p4_b = [-0.0865752, 0.085, 0.0108557]
+kq_d_kt = 0.011
 
 # concatenate the parameters to make a new list
 # fmt: off

--- a/aerial_robot_control/scripts/nmpc/nmpc_tilt_mt/tilt_bi/phys_param_birotor.py
+++ b/aerial_robot_control/scripts/nmpc/nmpc_tilt_mt/tilt_bi/phys_param_birotor.py
@@ -1,45 +1,27 @@
-"""
-Created by li-jinjie on 24-10-17.
-"""
+# 2025-10-08 copy parameters to be independent of any ROS package
+# these parameters are used in GitHub action to ensure the correctness of the nmpc code
+# In real usage, these parameters will be reloaded from URDF.
 
-import os
-import yaml
-import rospkg
-
-# read parameters from yaml
-rospack = rospkg.RosPack()
-try:
-    param_path = os.path.join(rospack.get_path("gimbalrotor"), "config", "PhysParamBirotor.yaml")
-except rospkg.common.ResourceNotFound:  # non-ROS environment
-    # Fallback: construct absolute path from current file
-    this_dir = os.path.dirname(os.path.abspath(__file__))
-    project_root = os.path.abspath(os.path.join(this_dir, "../../../../.."))
-    param_path = os.path.join(project_root, "robots/gimbalrotor/config/PhysParamBirotor.yaml")
-
-with open(param_path, "r") as f:
-    param_dict = yaml.load(f, Loader=yaml.FullLoader)
-
-physical_params = param_dict["physical"]
-mass = physical_params["mass"]
-gravity = physical_params["gravity"]
-Ixx = physical_params["inertia_diag"][0]
-Iyy = physical_params["inertia_diag"][1]
-Izz = physical_params["inertia_diag"][2]
-dr1 = physical_params["dr1"]
-p1_b = physical_params["p1"]
-dr2 = physical_params["dr2"]
-p2_b = physical_params["p2"]
-kq_d_kt = physical_params["kq_d_kt"]
+mass = 1.44441  # sim: 1.44441 # kg
+gravity = 9.798  # sim: 9.80665 # m/s^2   Tokyo 9.798; in sim: 9.80665
+Ixx = 0.055429
+Iyy = 0.017873
+Izz = 0.067851
+dr1 = 1
+p1_b = [0.0, 0.2375, 0.12098]
+dr2 = -1
+p2_b = [0, -0.2375, 0.12098]
+kq_d_kt = 0.0172
 
 # servo parameters
 ## 1-ord
-t_servo = physical_params["t_servo"]  # time constant of servo
+t_servo = 0.15858  # time constant of servo
 
 ## 2-ord
-kps = physical_params["kps"]
-kds = physical_params["kds"]  # kds has included the damping ratio
+kps = 72.7570
+kds = 11.5368  # kds has included the damping ratio
 
-i_sxx = physical_params["servo_inertia_x"]
+i_sxx = 0.0036697  # 0.0036697 calculated from UDRF
 
 # concatenate the parameters to make a new list
 # fmt: off

--- a/aerial_robot_control/scripts/nmpc/nmpc_tilt_mt/tilt_qd/phys_param_beetle_omni.py
+++ b/aerial_robot_control/scripts/nmpc/nmpc_tilt_mt/tilt_qd/phys_param_beetle_omni.py
@@ -1,46 +1,27 @@
-"""
- Created by li-jinjie on 24-10-5.
-"""
+# 2025-10-08 copy parameters to be independent of any ROS package
+# these parameters are used in GitHub action to ensure the correctness of the nmpc code
+# In real usage, these parameters will be reloaded from URDF.
 
-import yaml
-import os
-import rospkg
+mass = 3.0386
+gravity = 9.798
+Ixx = 0.0627958
+Iyy = 0.0620796
+Izz = 0.0948795
+dr1 = 1
+dr2 = -1
+dr3 = 1
+dr4 = -1
+p1_b = [0.194824, 0.194652, -0.00368224]
+p2_b = [-0.194837, 0.194652, -0.00368224]
+p3_b = [-0.194837, -0.195008, -0.00368224]
+p4_b = [0.194824, -0.195008, -0.00368224]
+kq_d_kt = 0.0165
 
-# read parameters from yaml
-rospack = rospkg.RosPack()
+t_servo = 0.0480  # time constant of servo
+t_rotor = 0.0942  # time constant of rotor
 
-try:
-    physical_param_path = os.path.join(rospack.get_path("beetle_omni"), "config", "PhysParamBeetleOmni.yaml")
-except rospkg.common.ResourceNotFound:  # non-ROS environment
-    # Fallback: construct absolute path from current file
-    this_dir = os.path.dirname(os.path.abspath(__file__))
-    project_root = os.path.abspath(os.path.join(this_dir, "../../../../.."))
-    physical_param_path = os.path.join(project_root, "robots/beetle_omni/config/PhysParamBeetleOmni.yaml")
-
-with open(physical_param_path, "r") as f:
-    physical_param_dict = yaml.load(f, Loader=yaml.FullLoader)
-physical_params = physical_param_dict["physical"]
-
-mass = physical_params["mass"]
-gravity = physical_params["gravity"]
-Ixx = physical_params["inertia_diag"][0]
-Iyy = physical_params["inertia_diag"][1]
-Izz = physical_params["inertia_diag"][2]
-dr1 = physical_params["dr1"]
-dr2 = physical_params["dr2"]
-dr3 = physical_params["dr3"]
-dr4 = physical_params["dr4"]
-p1_b = physical_params["p1"]
-p2_b = physical_params["p2"]
-p3_b = physical_params["p3"]
-p4_b = physical_params["p4"]
-kq_d_kt = physical_params["kq_d_kt"]
-
-t_servo = physical_params["t_servo"]  # time constant of servo
-t_rotor = physical_params["t_rotor"]  # time constant of rotor
-
-ball_effector_p = physical_params["ball_effector_p"]
-ball_effector_q = physical_params["ball_effector_q"]  # qw, qx, qy, qz
+ball_effector_p = [0, 0, 0.264]
+ball_effector_q = [1, 0, 0, 0]  # qw, qx, qy, qz
 
 # concatenate the parameters to make a new list
 # fmt: off

--- a/aerial_robot_control/scripts/nmpc/nmpc_tilt_mt/tilt_tri/phys_param_trirotor.py
+++ b/aerial_robot_control/scripts/nmpc/nmpc_tilt_mt/tilt_tri/phys_param_trirotor.py
@@ -1,40 +1,21 @@
-"""
-Created by li-jinjie on 24-10-17.
-"""
+# 2025-10-08 copy parameters to be independent of any ROS package
+# these parameters are used in GitHub action to ensure the correctness of the nmpc code
+# In real usage, these parameters will be reloaded from URDF.
 
-import os
-import yaml
-import rospkg
+mass = 1.52127  # sim: 1.52127 # kg
+gravity = 9.798
+Ixx = 0.025102
+Iyy = 0.0190842
+Izz = 0.0387961
+dr1 = 1
+p1_b = [0.0864353, -0.23752, 0.0259075]
+dr2 = -1
+p2_b = [0.0864353, 0.23748, 0.0259075]
+dr3 = 1
+p3_b = [-0.211065, -0.00002, 0.0259075]
+kq_d_kt = 0.0172  # sim: 0.0172
 
-# read parameters from yaml
-rospack = rospkg.RosPack()
-
-try:
-    param_path = os.path.join(rospack.get_path("gimbalrotor"), "config", "PhysParamTrirotor.yaml")
-except rospkg.common.ResourceNotFound:  # non-ROS environment
-    # Fallback: construct absolute path from current file
-    this_dir = os.path.dirname(os.path.abspath(__file__))
-    project_root = os.path.abspath(os.path.join(this_dir, "../../../../.."))
-    param_path = os.path.join(project_root, "robots/gimbalrotor/config/PhysParamTrirotor.yaml")
-
-with open(param_path, "r") as f:
-    param_dict = yaml.load(f, Loader=yaml.FullLoader)
-
-physical_params = param_dict["physical"]
-mass = physical_params["mass"]
-gravity = physical_params["gravity"]
-Ixx = physical_params["inertia_diag"][0]
-Iyy = physical_params["inertia_diag"][1]
-Izz = physical_params["inertia_diag"][2]
-dr1 = physical_params["dr1"]
-p1_b = physical_params["p1"]
-dr2 = physical_params["dr2"]
-p2_b = physical_params["p2"]
-dr3 = physical_params["dr3"]
-p3_b = physical_params["p3"]
-kq_d_kt = physical_params["kq_d_kt"]
-
-t_servo = physical_params["t_servo"]  # time constant of servo
+t_servo = 0.085883  # time constant of servo
 
 # concatenate the parameters to make a new list
 # fmt: off


### PR DESCRIPTION
### What is this

The parameters in current system is not set by python file anymore. Actually, all parameters will be reload in C++ code. Hence, we can remove the dependency to ROS package.

These python parameter files are still needed for python test.