### PR TITLE
Refine singularity rotation to increase robustness

### DIFF
--- a/aerial_robot_control/include/aerial_robot_control/nmpc/tilt_mt_servo_nmpc_controller.h
+++ b/aerial_robot_control/include/aerial_robot_control/nmpc/tilt_mt_servo_nmpc_controller.h
@@ -112,8 +112,9 @@ protected:
 
   // For singularity points
   int alloc_type_ = 0;
+  double ft_thresh_bias_;
   double ft_thresh_;
-  int rotor_idx_prev_ = -1;
+  int fix_rotor_idx_prev_ = -1;
   Eigen::MatrixXd alloc_mat_del_rotor_inv_;
 
   // For fixing rotor
@@ -128,6 +129,8 @@ protected:
   void initGeneralParams() override;
   void initNMPCCostW() override;
   void initNMPCConstraints() override;
+
+  void calcFtThresh();
 
   void setControlMode();
   virtual inline void initActuatorStates()

--- a/aerial_robot_control/src/nmpc/tilt_mt_servo_nmpc_controller.cpp
+++ b/aerial_robot_control/src/nmpc/tilt_mt_servo_nmpc_controller.cpp
@@ -59,8 +59,10 @@ void nmpc::TiltMtServoNMPC::initialize(ros::NodeHandle nh, ros::NodeHandle nhp,
 
 void nmpc::TiltMtServoNMPC::activate()
 {
+  // these functions are put here to wait for the physical parameters to be updated
   initAllocMat();
   updateInertialParams();
+  calcFtThresh();
 
   if (is_print_phys_params_)
     printPhysicalParams();
@@ -145,8 +147,8 @@ void nmpc::TiltMtServoNMPC::initGeneralParams()
   ros::NodeHandle alloc_nh(control_nh, "alloc");
 
   getParam<int>(alloc_nh, "type", alloc_type_, 0);
-  getParam<double>(alloc_nh, "ft_thresh", ft_thresh_, 0.5);
-  if (ft_thresh_ <= 0.0)
+  getParam<double>(alloc_nh, "ft_thresh_bias", ft_thresh_bias_, 0.5);
+  if (ft_thresh_bias_ <= 0.0)
     throw std::runtime_error(
         "ft_thresh must be greater than zero! Please set a positive value for ft_thresh in the parameter server.");
 
@@ -316,6 +318,24 @@ void nmpc::TiltMtServoNMPC::setControlMode()
 
   ROS_INFO("Set control mode: attitude = %d and body rate = %d", set_control_mode_srv.request.is_attitude,
            set_control_mode_srv.request.is_body_rate);
+}
+
+void nmpc::TiltMtServoNMPC::calcFtThresh()
+{
+  int rotor_num = robot_model_->getRotorNum();  // For tilt-rotor, rotor_num = servo_num
+  const auto& rotor_p = robot_model_->getRotorsOriginFromCog<Eigen::Vector3d>();
+
+  double ft_thresh_max = 0.0;
+  for (int i = 0; i < rotor_num; i++)
+  {
+    Eigen::Vector3d p_b = rotor_p[i];
+
+    double ft_thresh = mass_ * gravity_const_ * abs(p_b.z()) / sqrt(p_b.x() * p_b.x() + p_b.y() * p_b.y());
+    if (ft_thresh > ft_thresh_max)
+      ft_thresh_max = ft_thresh;
+  }
+
+  ft_thresh_ = ft_thresh_max + ft_thresh_bias_;
 }
 
 void nmpc::TiltMtServoNMPC::initAllocMat()
@@ -838,7 +858,7 @@ void nmpc::TiltMtServoNMPC::allocateToXUwOneFixedRotor(int fix_rotor_idx, double
   Eigen::VectorXd tgt_wrench_modified = ref_wrench_b - tgt_wrench_from_rotor;
 
   // 3) calculate the allocation matrix without this rotor, which is 6*6
-  if (fix_rotor_idx != rotor_idx_prev_)
+  if (fix_rotor_idx != fix_rotor_idx_prev_)
   {
     Eigen::MatrixXd alloc_mat_del_rotor(alloc_mat_.rows(), alloc_mat_.cols() - 2);
     int j = 0;
@@ -880,7 +900,7 @@ void nmpc::TiltMtServoNMPC::allocateToXUwOneFixedRotor(int fix_rotor_idx, double
   }
 
   // if the fixed rotor is the same with previous one, no need to recalculate the allocation matrix.
-  rotor_idx_prev_ = fix_rotor_idx;
+  fix_rotor_idx_prev_ = fix_rotor_idx;
 }
 
 /**

--- a/robots/beetle_omni/config/BeetleNMPCFullDist.yaml
+++ b/robots/beetle_omni/config/BeetleNMPCFullDist.yaml
@@ -4,7 +4,7 @@ aerial_robot_control_name: aerial_robot_control/nmpc_controller/tilt_mt/servo_di
 controller:
   alloc:
     type: 1  # 0: pseudo allocation, 1: heuristic allocation,
-    ft_thresh: 1.0  # N
+    ft_thresh_bias: 1.0  # N
 
   nmpc:
     T_samp: 0.01  # 100 Hz  TODO: should be adjusted by main_rate

--- a/robots/beetle_omni/config/BeetleNMPCFullDist.yaml
+++ b/robots/beetle_omni/config/BeetleNMPCFullDist.yaml
@@ -4,7 +4,7 @@ aerial_robot_control_name: aerial_robot_control/nmpc_controller/tilt_mt/servo_di
 controller:
   alloc:
     type: 1  # 0: pseudo allocation, 1: heuristic allocation,
-    ft_thresh_bias: 1.0  # N
+    ft_thresh_bias: 1.5  # N
 
   nmpc:
     T_samp: 0.01  # 100 Hz  TODO: should be adjusted by main_rate


### PR DESCRIPTION
### What is this

The previous method to pass the singularity points rely on a constant value, sometimes may fail when the end-effector is too heavy. Now add a function to calculate the threshold based on the position from CoG to rotors.

Also increase the bias term for better performance.

Tested on fork, ball, brush, and sensor_ball, in simulation.